### PR TITLE
Fix query: DeviceStatus

### DIFF
--- a/gluco-check-core/src/main/clients/NightscoutClient-Queries.ts
+++ b/gluco-check-core/src/main/clients/NightscoutClient-Queries.ts
@@ -30,8 +30,8 @@ export const DeviceStatus = {
     DiabetesPointer.InsulinOnBoard,
     DiabetesPointer.PumpBattery,
   ],
-  path: '/api/v1/devicestatus',
-  params: {sort$desc: 'created_at', count: 1},
+  path: '/api/v3/devicestatus',
+  params: {sort$desc: 'created_at', limit: 1, 'pump.clock$gte': '1970-01-01'},
   callback: (data: any) => {
     return {
       carbsOnBoard: data.openaps.suggested.COB,

--- a/gluco-check-core/src/main/clients/NightscoutClient-Queries.ts
+++ b/gluco-check-core/src/main/clients/NightscoutClient-Queries.ts
@@ -31,7 +31,7 @@ export const DeviceStatus = {
     DiabetesPointer.PumpBattery,
   ],
   path: '/api/v3/devicestatus',
-  params: {sort$desc: 'created_at', limit: 1, 'pump.clock$gte': '1970-01-01'},
+  params: {sort$desc: 'created_at', limit: 1, 'pump.clock$gte': ''},
   callback: (data: any) => {
     return {
       carbsOnBoard: data.openaps.suggested.COB,

--- a/gluco-check-core/test/stubs/AxiosMockAdapter.ts
+++ b/gluco-check-core/test/stubs/AxiosMockAdapter.ts
@@ -14,7 +14,7 @@ const respondWithMockData = () => {
   mock.reset();
 
   mock.onGet(`${baseUrl}/v1/entries/current`).reply(() => [200, stub_currentEntry]);
-  mock.onGet(`${baseUrl}/v1/devicestatus`).reply(() => [200, stub_deviceStatus]);
+  mock.onGet(`${baseUrl}/v3/devicestatus`).reply(() => [200, stub_deviceStatus]);
 
   mock.onGet(`${baseUrl}/v3/treatments`).reply(config => {
     // Depending on requested treatment, respond w/ different mock data


### PR DESCRIPTION
Fixes #11 by switching to v3 api calls