### PR TITLE
fix: slow cold starts

### DIFF
--- a/gluco-check-core/src/main/clients/NightscoutClient-Queries.ts
+++ b/gluco-check-core/src/main/clients/NightscoutClient-Queries.ts
@@ -12,6 +12,7 @@ import {DiabetesPointer} from '../../types/DiabetesPointer';
  * - a callback function that gets the required data from the http response
  */
 export const BloodSugar = {
+  key: 0,
   pointers: DiabetesPointer.BloodSugar,
   path: '/api/v1/entries/current',
   params: {},
@@ -25,6 +26,7 @@ export const BloodSugar = {
 };
 
 export const DeviceStatus = {
+  key: 1,
   pointers: [
     DiabetesPointer.CarbsOnBoard,
     DiabetesPointer.InsulinOnBoard,
@@ -43,6 +45,7 @@ export const DeviceStatus = {
 };
 
 export const CannulaAge = {
+  key: 2,
   pointers: [DiabetesPointer.CannulaAge],
   path: '/api/v3/treatments',
   params: {eventType: 'Site Change', sort$desc: 'created_at', limit: 1},
@@ -54,6 +57,7 @@ export const CannulaAge = {
 };
 
 export const SensorAge = {
+  key: 3,
   pointers: [DiabetesPointer.SensorAge],
   path: '/api/v3/treatments',
   params: {eventType: 'Sensor Change', sort$desc: 'created_at', limit: 1},

--- a/gluco-check-core/src/main/core/DiabetesQueryResolver.ts
+++ b/gluco-check-core/src/main/core/DiabetesQueryResolver.ts
@@ -39,7 +39,7 @@ export default class DiabetesQueryResolver {
       Object.assign(snapshot, part);
     });
 
-    logger.info(`[DiabetesQueryResolver]: Total query time: ${totalQueryTime} ms.`);
+    logger.info(`[DiabetesQueryResolver]: Nightscout queries took ${totalQueryTime} ms.`);
     return this.responseFormatter.formatSnapshot(snapshot, query);
   }
 }

--- a/gluco-check-core/src/main/core/ResponseFormatter.ts
+++ b/gluco-check-core/src/main/core/ResponseFormatter.ts
@@ -50,7 +50,7 @@ export default class ResponseFormatter {
         sayPointerName: query.pointers.length > 1,
       };
       const humanPointer = await humanizePointer(pointer, params);
-      logger.info('[ResponseFormatter]:', humanPointer);
+      logger.debug('[ResponseFormatter]:', humanPointer);
       return `<s>${humanPointer} </s>`; // Note the space at the end of each pointer!
     });
 

--- a/gluco-check-core/src/main/i18n/Humanizers.ts
+++ b/gluco-check-core/src/main/i18n/Humanizers.ts
@@ -49,7 +49,7 @@ export async function formatCarbsOnBoard(params: FormatParams): Promise<string> 
 
 export async function formatInsulinOnBoard(params: FormatParams): Promise<string> {
   const ctx = {
-    value: round(params.snapshot.insulinOnBoard, 2),
+    value: round(params.snapshot.insulinOnBoard),
     time: await translateTimestamp(params.snapshot.timestamp, params.locale),
   };
 

--- a/gluco-check-core/src/main/i18n/Localizer.ts
+++ b/gluco-check-core/src/main/i18n/Localizer.ts
@@ -65,29 +65,25 @@ export default class Localizer {
  * 300000 ==> '5 minutes'
  * @returns The id of the locale that was loaded. Pass this id to dayjs(foo).locale(id)
  */
-export async function loadDayJsLocale(locale: string): Promise<string> {
+export async function loadDayJsLocale(_locale: string): Promise<string> {
   // DayJs uses lowercase to identify its locales
-  locale = locale.toLowerCase();
+  const locale = _locale.toLowerCase();
+  const fallback = locale.substr(0, 2);
 
   // Bail if locale (or its fallback) was loaded previously
   if (loadedDayJsLocales.has(locale)) return locale;
-  const fallback = locale.substr(0, 2);
   if (loadedDayJsLocales.has(fallback)) return fallback;
 
+  logger.debug(`[Localizer.DayJS]: Importing locale: ${locale}`);
   try {
     // Attempt loading the exact locale
-    await import(`dayjs/locale/${locale}`);
     loadedDayJsLocales.add(locale);
+    await import(`dayjs/locale/${locale}`);
     return locale;
   } catch (error) {
     // Attempt loading the fallback
-    logger.warn(
-      `[Localizer.DayJS]: No locale for '${locale}'.`,
-      `Attempting fallback to '${fallback}'`
-    );
-    await import(`dayjs/locale/${fallback}`);
     loadedDayJsLocales.add(fallback);
-    logger.info('[Localizer.DayJs]: Fallback successful');
+    await import(`dayjs/locale/${fallback}`);
     return fallback;
   }
 }

--- a/gluco-check-webhooks/deploy-hooks.js
+++ b/gluco-check-webhooks/deploy-hooks.js
@@ -46,7 +46,7 @@ const preDeploy = () => {
   // Write updated package.json
   fs.existsSync(filenamePackageBackup) && fs.unlinkSync(filenamePackageBackup);
   fs.renameSync(filenamePackage, filenamePackageBackup);
-  fs.writeFileSync(filenamePackage, JSON.stringify(package));
+  fs.writeFileSync(filenamePackage, JSON.stringify(package, null, 2));
 };
 
 const postDeploy = () => {


### PR DESCRIPTION
Importing of DayJS is repeated when the function cold-boots. This PR fixes this.  
Also, some Nightscout queries may be repeated, this PR fixes caching to prevent doing the same API request more than once