### PR TITLE
fix: Read IOB and COB from Loop

### DIFF
--- a/gluco-check-core/src/main/clients/NightscoutClient-Queries.ts
+++ b/gluco-check-core/src/main/clients/NightscoutClient-Queries.ts
@@ -36,9 +36,9 @@ export const DeviceStatus = {
   params: {sort$desc: 'created_at', limit: 1, 'pump.clock$gte': ''},
   callback: (data: any) => {
     return {
-      carbsOnBoard: data.openaps.suggested.COB,
-      insulinOnBoard: data.openaps.iob.iob,
-      pumpBattery: data.pump.battery.percent,
+      carbsOnBoard: data.openaps?.suggested?.COB || data.loop?.cob.cob,
+      insulinOnBoard: data.openaps?.iob.iob || data.loop?.iob.iob,
+      pumpBattery: data.pump.battery?.percent,
       timestamp: new Date(data.created_at).getTime(),
     };
   },

--- a/gluco-check-core/src/main/clients/NightscoutClient.ts
+++ b/gluco-check-core/src/main/clients/NightscoutClient.ts
@@ -89,6 +89,7 @@ export default class NightscoutClient {
 
       // Handle errors
     } catch (error) {
+      logger.warn(`Error querying Nightscout '${request.url}': ${error}`);
       if (error.response?.status === 401) {
         throw ErrorTypes.NightscoutUnauthorized;
       }


### PR DESCRIPTION
Fixes #16 
Loop stores values such as IOB, COB in a different schema (compared to OpenAPS)  
Nightscout Queries should be updated to extract the Loop-equivalents of these DiabetesPointers