### PR TITLE
Upgrade Axios to 0.21.0

### DIFF
--- a/gluco-check-core/package.json
+++ b/gluco-check-core/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@assistant/conversation": "^3.1.0",
-    "axios": "^0.20.0",
+    "axios": "^0.21.0",
     "dayjs": "^1.9.1",
     "firebase-admin": "^9.2.0",
     "firebase-functions": "^3.11.0",

--- a/gluco-check-core/src/main/clients/NightscoutClient.ts
+++ b/gluco-check-core/src/main/clients/NightscoutClient.ts
@@ -1,9 +1,6 @@
 // HTTP response cache can contain 'any' types
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-// FIXME: Required because of: https://github.com/axios/axios/issues/3219
-/// <reference lib="DOM" />
-
 import axios, {AxiosRequestConfig} from 'axios';
 import NightscoutProps from '../../types/NightscoutProps';
 import {URL} from 'url';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1206,10 +1206,10 @@ axios-mock-adapter@^1.18.2:
     fast-deep-equal "^3.1.1"
     is-buffer "^2.0.3"
 
-axios@^0.20.0:
-  version "0.20.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.20.0.tgz#057ba30f04884694993a8cd07fa394cff11c50bd"
-  integrity sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==
+axios@^0.21.0:
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.0.tgz#26df088803a2350dff2c27f96fef99fe49442aca"
+  integrity sha512-fmkJBknJKoZwem3/IKSSLpkdNXZeBu5Q7GA/aRsr2btgrptmSCxi2oFjZHqGdK9DoTil9PIHlPIZw2EcRJXRvw==
   dependencies:
     follow-redirects "^1.10.0"
 


### PR DESCRIPTION
This fixes the dependency on typescript DOM lib in NightscoutClient

## Motivation and Context
The following [bug](https://github.com/axios/axios/issues/3219) in Axios required the Typescript DOM lib to be referenced, even though this is a pure nodejs project with no dependencies on DOM

## How Has This Been Tested?
This only changes a dependency version. Tests should still be passing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've made my changes in a separate `fix/` or `feature/` branch
- [ ] My change requires a change to the documentation/website
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
- [x] I've written tests to cover my change
- [ ] My change is passing new and existing tests