### PR TITLE
fix(NightscoutClient): Query returns no data

### DIFF
--- a/gluco-check-core/src/types/ErrorType.ts
+++ b/gluco-check-core/src/types/ErrorType.ts
@@ -5,9 +5,6 @@ export enum ErrorType {
   // HTTP 401 Unauthorized error from Nightscout
   Nightscout_Unauthorized = 'Nightscout Unauthorized',
 
-  // Nightscout responses must have exactly 1 item
-  Nightscout_UnexpectedNrOfItems = 'Nightscout Unexpected number of items',
-
   // Nightscout responded, but response did not contain the requested info
   QueryResponse_MetricNotFound = 'DmMetric Not Found',
 


### PR DESCRIPTION
If a query returns no data, it is now reported as a MetricNotFound error.
This used to be a fail that marked the entire Query as invalid.

<!--- Provide a general summary of your changes in the Title above -->
<!--- The template is a guideline, not a test :) All PRs are welcome! -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've made my changes in a separate `fix/` or `feature/` branch
- [ ] My change requires a change to the documentation/website
- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
- [ ] I've written tests to cover my change
- [ ] My change is passing new and existing tests