### PR TITLE
Select fallback for locales with no exact match

### DIFF
--- a/gluco-check-core/src/main/i18n/index.ts
+++ b/gluco-check-core/src/main/i18n/index.ts
@@ -1,6 +1,7 @@
 import {TFunction, i18n} from 'i18next';
 import {logger} from 'firebase-functions';
 import {injectable} from 'inversify';
+import selectFallbackLocale from './selectFallbackLocale';
 
 // i18next won't work unless we import it using 'require'
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -38,8 +39,7 @@ export default class I18nHelper {
     try {
       resourceBundle = this.importResources(locale);
     } catch {
-      // Fallback to generic language bundle if not found
-      const fallback = locale.substr(0, 2);
+      const fallback = selectFallbackLocale(locale);
       logger.debug(
         `[Localizer.I18Next]: No exact translation for ${locale}.`,
         `Attempting fallback to ${fallback}`

--- a/gluco-check-core/src/main/i18n/selectFallbackLocale.ts
+++ b/gluco-check-core/src/main/i18n/selectFallbackLocale.ts
@@ -1,0 +1,46 @@
+export default function selectFallbackLocale(locale: string) {
+  return toCustomLocale(locale) || toGenericLocale(locale);
+}
+
+/**
+ * Returns a custom locale if one is defined
+ * @param locale Full locale such as en-US, sv-SE, ...
+ */
+function toCustomLocale(locale: string) {
+  return customFallbackMap.get(locale);
+}
+
+/**
+ * Returns a locale that can be used as generic
+ * @param locale Full locale such as en-US, sv-SE, ...
+ */
+function toGenericLocale(locale: string) {
+  const twoLetterLnCode = locale.substr(0, 2);
+
+  const fallback = genericFallbackMap.get(twoLetterLnCode);
+  if (fallback) return fallback;
+  else {
+    const e = `[SelectFallbackLocale]: Unable to find a resource bundle for '${locale}'.`;
+    throw new Error(e);
+  }
+}
+
+const genericFallbackMap = new Map<string, string>([
+  // Map generic locales to specific locales here
+  ['en', 'en-US'],
+  ['da', 'da-DK'],
+  ['de', 'de-DE'],
+  ['es', 'es-ES'],
+  ['fr', 'fr-FR'],
+  ['it', 'it-IT'],
+  ['nl', 'nl-NL'],
+  ['pl', 'pl-PL'],
+  ['pt', 'pt-BR'],
+  ['ru', 'ru-RU'],
+  ['sv', 'sv-SE'],
+]);
+
+const customFallbackMap = new Map<string, string>([
+  // Add custom mappings here
+  // ['no-NO', 'nb-NB']
+]);

--- a/gluco-check-core/test/specs/i18n/locales.spec.ts
+++ b/gluco-check-core/test/specs/i18n/locales.spec.ts
@@ -41,6 +41,27 @@ describe('Disclaimer', () => {
     const actualDisclaimer = Humanizer.disclaimer(locale);
     expect(actualDisclaimer).toEqual(expectedDisclaimer);
   });
+
+  it('falls back to generic language', async () => {
+    try {
+      await new I18nHelper().ensureLocale('nl-BE');
+    } catch (error) {
+      fail(error);
+    }
+  });
+
+  it('throws an error when no resource bundle found', done => {
+    const promise = new I18nHelper().ensureLocale('123-NO-REAL-LOCALE');
+    promise
+      .then(() => {
+        // This promise should not succeed
+        fail();
+      })
+      .catch(() => {
+        // Error is expected
+        done();
+      });
+  });
 });
 
 async function runTest(locale: string, expectedString: string) {


### PR DESCRIPTION
## Description
If no exact match is found for a locale, falls back according to a predefined map

## Motivation and Context
Fixes #43 

## How Has This Been Tested?
Invoke the action with an Assistant set to 'en-CA' (or any other English locale other than en-US)

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've made my changes in a separate `fix/` or `feature/` branch
- [x] My change requires a change to the documentation/website
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
- [ ] I've written tests to cover my change
- [ ] My change is passing new and existing tests