### PR TITLE
fix: Catch invalid URLs

### DIFF
--- a/gluco-check-core/src/main/core/QueryResolver.ts
+++ b/gluco-check-core/src/main/core/QueryResolver.ts
@@ -17,7 +17,10 @@ export default class QueryResolver {
   async buildSnapshot(query: DmQuery): Promise<DmSnapshot> {
     // Ensure user exists and has a Nightscout Site
     if (!query.user.exists || !query.user.nightscout) {
-      return this.userNotFoundError(query);
+      return this.errorResponse(query, ErrorType.Firebase_UserNotFound);
+    }
+    if (!query.user.nightscout.hasValidUrl) {
+      return this.errorResponse(query, ErrorType.Nightscout_Unavailable);
     }
 
     // Create an empty snapshot. We'll add requested Metrics in here
@@ -45,13 +48,13 @@ export default class QueryResolver {
     return newSnapshot;
   }
 
-  private userNotFoundError(query: DmQuery) {
+  private errorResponse(query: DmQuery, errorType: ErrorType) {
     return new DmSnapshot({
       timestamp: Date.now(),
       query,
       errors: [
         {
-          type: ErrorType.Firebase_UserNotFound,
+          type: errorType,
           affectedMetric: DmMetric.Everything,
         },
       ],

--- a/gluco-check-core/src/types/NightscoutProps.ts
+++ b/gluco-check-core/src/types/NightscoutProps.ts
@@ -1,3 +1,5 @@
+import {URL} from 'url';
+
 export default class NightscoutProps {
   constructor(private _url: string, private _token?: string) {}
 
@@ -7,5 +9,14 @@ export default class NightscoutProps {
 
   get token(): string | undefined {
     return this._token;
+  }
+
+  get hasValidUrl(): boolean {
+    try {
+      new URL(this._url);
+      return true;
+    } catch (error) {
+      return false;
+    }
   }
 }

--- a/gluco-check-core/test/specs/main/core/QueryResolver.spec.ts
+++ b/gluco-check-core/test/specs/main/core/QueryResolver.spec.ts
@@ -5,6 +5,7 @@ import QueryResolver from '../../../../src/main/core/QueryResolver';
 import AxiosMockAdapter from '../../../stubs/AxiosMockAdapter';
 import getFakeQuery from '../../../fakes/objects/fakeDmQuery';
 import {ErrorType} from '../../../../src/types/ErrorType';
+import NightscoutProps from '../../../../src/types/NightscoutProps';
 
 describe('QueryResolver', () => {
   AxiosMockAdapter.respondWithMockData();
@@ -15,6 +16,14 @@ describe('QueryResolver', () => {
     const result = await new QueryResolver().buildSnapshot(fakeQuery);
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0].type).toBe(ErrorType.Firebase_UserNotFound);
+  });
+
+  it('returns an error when the url is invalid', async () => {
+    const fakeQuery = getFakeQuery();
+    fakeQuery.user.nightscout = new NightscoutProps('invalid-url');
+    const result = await new QueryResolver().buildSnapshot(fakeQuery);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].type).toBe(ErrorType.Nightscout_Unavailable);
   });
 
   it('returns an error when user has no Nightscout site', async () => {


### PR DESCRIPTION
## Description
When a user has saved an invalid URL in firebase (ie a url that can't be parsed by `new URL()`),  
GlucoCheck will now reply with the `NS Unavailable` error

## Motivation and Context
Someone managed to save an invalid URL into Firebase. This caused the action to fail completely.  
This fix will catch the error and return a useful response instead.

## How Has This Been Tested?
Additional specs added

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've made my changes in a separate `fix/` or `feature/` branch
- [x] My change requires a change to the documentation/website
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
- [x] I've written tests to cover my change
- [x] My change is passing new and existing tests