### PR TITLE
Parse token from URLs

### DIFF
--- a/gluco-check-core/src/main/clients/nightscout/NightscoutValidator.ts
+++ b/gluco-check-core/src/main/clients/nightscout/NightscoutValidator.ts
@@ -41,7 +41,11 @@ export default class NightscoutValidator {
   }
 
   private static async validateToken(_token = '', url: string) {
-    const token = _token.trim();
+    let token = _token.trim();
+    if (token.startsWith(url)) {
+      // Token was copied from Nightscout as a URL
+      token = new URL(token).searchParams.get('token') || token;
+    }
 
     logger.info(logTag, 'Attempting to access v1 API using token @', url);
     try {

--- a/gluco-check-core/src/main/core/AuthTokenDecoder.ts
+++ b/gluco-check-core/src/main/core/AuthTokenDecoder.ts
@@ -20,7 +20,7 @@ export default class AuthTokenDecoder {
 
     if (!this.clientId)
       throw new Error(
-        `${logTag} Firebase Functions config must define an auth.client_id property`
+        `${logTag} Firebase Functions config must define client_id property`
       );
   }
 

--- a/gluco-check-core/src/main/utils.ts
+++ b/gluco-check-core/src/main/utils.ts
@@ -1,0 +1,10 @@
+/* eslint-disable */
+
+export const flattenDeep = function (arr: any): any[] {
+  return Array.isArray(arr)
+    ? arr.reduce((a, b) => [...flattenDeep(a), ...flattenDeep(b)], [])
+    : [arr];
+};
+
+export const intersection = (arr: any[], ...args: any[]) =>
+  arr.filter((item: any) => args.every(arr => arr.includes(item)));

--- a/gluco-check-core/test/specs/main/clients/NightscoutValidator.spec.ts
+++ b/gluco-check-core/test/specs/main/clients/NightscoutValidator.spec.ts
@@ -40,6 +40,16 @@ describe('Nightscout Validator', () => {
     expect(results.token.isValid).toBeTruthy();
   });
 
+  it('parses a token inside a url', async () => {
+    AxiosMock.respondWithMockData();
+    const testUrl = 'https://cgm.example.com';
+    const testToken = `${testUrl}?token=test-token`;
+    const results = await runTestValidation(testUrl, testToken);
+
+    expect(results.token.isValid).toBeTruthy();
+    expect(results.token.parsed).toBe('test-token');
+  });
+
   it('rejects an invalid token', async () => {
     AxiosMock.respondWith401Unauthorized();
     const testUrl = 'https://cgm.example.com';

--- a/gluco-check-core/test/specs/main/clients/NightscoutValidator.spec.ts
+++ b/gluco-check-core/test/specs/main/clients/NightscoutValidator.spec.ts
@@ -40,14 +40,14 @@ describe('Nightscout Validator', () => {
     expect(results.token.isValid).toBeTruthy();
   });
 
-  it('parses a token inside a url', async () => {
+  it('extracts token from url', async () => {
     AxiosMock.respondWithMockData();
     const testUrl = 'https://cgm.example.com';
-    const testToken = `${testUrl}?token=test-token`;
-    const results = await runTestValidation(testUrl, testToken);
+    const testToken = 'test-token';
+    const urlFormattedToken = `${testUrl}?token=${testToken}`;
+    const results = await runTestValidation(testUrl, urlFormattedToken);
 
-    expect(results.token.isValid).toBeTruthy();
-    expect(results.token.parsed).toBe('test-token');
+    expect(results.token.parsed).toBe(testToken);
   });
 
   it('rejects an invalid token', async () => {


### PR DESCRIPTION
## Description
When validating a Nightscout token, url-type tokens will now be parsed correctly

## Motivation and Context
When you add a new token in Nightscout and then click it, it will open as a url that looks like this:  
`https://cgm.example.com?token=abc123`. This PR will extract the token from such URLs in case a user enters them

## How Has This Been Tested?
Added spec

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've made my changes in a separate `fix/` or `feature/` branch
- [x] My change requires a change to the documentation/website
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
- [x] I've written tests to cover my change
- [ ] My change is passing new and existing tests