### PR TITLE
Add 'http://' to a url if user forgets it

### DIFF
--- a/gluco-check-core/src/main/clients/nightscout/NightscoutValidator.ts
+++ b/gluco-check-core/src/main/clients/nightscout/NightscoutValidator.ts
@@ -148,10 +148,10 @@ export default class NightscoutValidator {
 
   private static getBaseUrl(_url: string): {parsed: string; isValid: boolean} {
     try {
-      const url = _url.toLowerCase().trim();
+      let url = _url.toLowerCase().trim();
 
       const hasProtocol = url.startsWith('http://') || url.startsWith('https://');
-      if (!hasProtocol) throw new Error('Url must start with http:// or https://');
+      if (!hasProtocol) url = `http://${url}`;
 
       const parsedUrl = new URL(url);
       const hasTld = parsedUrl.hostname.includes('.');

--- a/gluco-check-core/test/specs/main/clients/NightscoutValidator.spec.ts
+++ b/gluco-check-core/test/specs/main/clients/NightscoutValidator.spec.ts
@@ -50,6 +50,16 @@ describe('Nightscout Validator', () => {
     expect(results.token.parsed).toBe(testToken);
   });
 
+  it('adds http if it is missing from url', async () => {
+    AxiosMock.respondWithMockData();
+    const testUrl = 'cgm.example.com';
+    const testToken = 'test-token';
+    const results = await runTestValidation(testUrl, testToken);
+
+    expect(results.url.isValid).toBeTruthy();
+    expect(results.url.parsed).toBe(`http://${testUrl}`);
+  });
+
   it('rejects an invalid token', async () => {
     AxiosMock.respondWith401Unauthorized();
     const testUrl = 'https://cgm.example.com';


### PR DESCRIPTION
Adding 'https://' or 'http://' to a url is frequently forgotton on Nightscout Status.  
This PR will modify the validation endpoint to add 'http://' if a user forgets it