### PR TITLE
changes focused label colour when in dark mode

### DIFF
--- a/gluco-check-frontend/src/components/SettingsForm.tsx
+++ b/gluco-check-frontend/src/components/SettingsForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { debounce } from "debounce";
 
 import {

--- a/gluco-check-frontend/src/components/SettingsForm.tsx
+++ b/gluco-check-frontend/src/components/SettingsForm.tsx
@@ -29,8 +29,10 @@ import {
 import semver from "semver";
 import { Close, Lock } from "@material-ui/icons";
 import MuiAlert from "@material-ui/lab/Alert";
+import { indigo } from "@material-ui/core/colors";
 import { useForm, Controller, DeepMap, FieldError } from "react-hook-form";
 import { useTranslation } from "react-i18next";
+
 import { BloodGlucoseUnit, DiabetesMetric } from "../lib/enums";
 import { SettingsFormData } from "../lib/types";
 import {
@@ -72,6 +74,13 @@ const useStyles = makeStyles((theme) => ({
     "& .MuiFormHelperText-root .MuiLink-button": {
       color: theme.palette.text.secondary,
       textDecoration: "underline",
+    },
+    "& .MuiFormLabel-root.Mui-focused": {
+      color: theme.palette.type === "light" ? indigo[500] : "#72aed3",
+    },
+    "& .MuiInputBase-root.MuiInput-underline:after": {
+      borderBottomColor:
+        theme.palette.type === "light" ? indigo[500] : "#72aed3",
     },
   },
   checkboxArray: {


### PR DESCRIPTION
## Description
In this PR we are updating the focused label colour used for the settings form when in dark mode, to improve contrast against the background.

## Motivation and Context
Current colour makes field labels difficult to read when they are focused.

## How Has This Been Tested?
Change has been tested manually.

## Additional context
paste issue image here, and after

## Types of changes
<!--- Delete lines that do not apply -->
* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)
* Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've made my changes in a separate branch
- [ ] I've updated documentation, or created an issue to do so later
- [ ] My change is passing new and existing tests