### PR TITLE
Bug: dark theme palette issue and colour contrast changes

### DIFF
--- a/gluco-check-frontend/src/components/SettingsForm.tsx
+++ b/gluco-check-frontend/src/components/SettingsForm.tsx
@@ -29,8 +29,10 @@ import {
 import semver from "semver";
 import { Close, Lock } from "@material-ui/icons";
 import MuiAlert from "@material-ui/lab/Alert";
+import { indigo } from "@material-ui/core/colors";
 import { useForm, Controller, DeepMap, FieldError } from "react-hook-form";
 import { useTranslation } from "react-i18next";
+
 import { BloodGlucoseUnit, DiabetesMetric } from "../lib/enums";
 import { SettingsFormData } from "../lib/types";
 import {
@@ -72,6 +74,13 @@ const useStyles = makeStyles((theme) => ({
     "& .MuiFormHelperText-root .MuiLink-button": {
       color: theme.palette.text.secondary,
       textDecoration: "underline",
+    },
+    "& .MuiFormLabel-root.Mui-focused": {
+      color: theme.palette.type === "light" ? indigo[500] : "#72aed3",
+    },
+    "& .MuiInputBase-root.MuiInput-underline:after": {
+      borderBottomColor:
+        theme.palette.type === "light" ? indigo[500] : "#72aed3",
     },
   },
   checkboxArray: {

--- a/gluco-check-frontend/src/components/ThemeWithMediaProvider.test.tsx
+++ b/gluco-check-frontend/src/components/ThemeWithMediaProvider.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render } from "@testing-library/react";
-import { themeOptions } from "../theme";
+import { lightThemeOptions } from "../theme";
 import ThemeWithMediaProvider from "./ThemeWithMediaProvider";
 
 import { useMediaQuery, createMuiTheme } from "@material-ui/core";
@@ -19,7 +19,7 @@ jest.mock("@material-ui/core", () => {
 describe("ThemeWithMediaProvider", () => {
   it("renders the wrapped children", () => {
     const { container } = render(
-      <ThemeWithMediaProvider themeOptions={themeOptions}>
+      <ThemeWithMediaProvider themeOptions={lightThemeOptions}>
         <div>Some Content</div>
       </ThemeWithMediaProvider>
     );
@@ -34,7 +34,7 @@ describe("ThemeWithMediaProvider", () => {
       expect(theme.palette).toMatchSnapshot();
     });
     render(
-      <ThemeWithMediaProvider themeOptions={themeOptions}>
+      <ThemeWithMediaProvider themeOptions={lightThemeOptions}>
         <div>Some Content</div>
       </ThemeWithMediaProvider>
     );
@@ -47,7 +47,7 @@ describe("ThemeWithMediaProvider", () => {
       expect(theme.palette).toMatchSnapshot();
     });
     render(
-      <ThemeWithMediaProvider themeOptions={themeOptions}>
+      <ThemeWithMediaProvider themeOptions={lightThemeOptions}>
         <div>Some Content</div>
       </ThemeWithMediaProvider>
     );

--- a/gluco-check-frontend/src/components/ThemeWithMediaProvider.tsx
+++ b/gluco-check-frontend/src/components/ThemeWithMediaProvider.tsx
@@ -8,7 +8,8 @@ import {
 } from "@material-ui/core";
 
 type ThemeWithMediaProviderProps = {
-  themeOptions: ThemeOptions;
+  lightThemeOptions: ThemeOptions;
+  darkThemeOptions: ThemeOptions;
   children: ReactNode;
 };
 
@@ -16,20 +17,22 @@ type ThemeWithMediaProviderProps = {
 // currently used to add dark mode support
 function ThemeWithMediaProvider({
   children,
-  themeOptions,
+  lightThemeOptions,
+  darkThemeOptions,
 }: ThemeWithMediaProviderProps) {
   const prefersDark = useMediaQuery("(prefers-color-scheme: dark)");
 
   const theme = React.useMemo(() => {
+    let themeToBlend = prefersDark ? darkThemeOptions : lightThemeOptions;
     let blendedTheme = createMuiTheme({
-      ...themeOptions,
       palette: {
         type: prefersDark ? "dark" : "light",
       },
+      ...themeToBlend,
     });
     blendedTheme = responsiveFontSizes(blendedTheme);
     return blendedTheme;
-  }, [prefersDark, themeOptions]);
+  }, [prefersDark, lightThemeOptions, darkThemeOptions]);
 
   return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
 }

--- a/gluco-check-frontend/src/index.tsx
+++ b/gluco-check-frontend/src/index.tsx
@@ -6,7 +6,7 @@ import App from "./App";
 
 import "./lib/i18n";
 import ThemeWithMediaProvider from "./components/ThemeWithMediaProvider";
-import { themeOptions } from "./theme";
+import { darkThemeOptions, lightThemeOptions } from "./theme";
 
 ReactDOM.render(
   <Suspense
@@ -24,7 +24,10 @@ ReactDOM.render(
       </Grid>
     }
   >
-    <ThemeWithMediaProvider themeOptions={themeOptions}>
+    <ThemeWithMediaProvider
+      lightThemeOptions={lightThemeOptions}
+      darkThemeOptions={darkThemeOptions}
+    >
       <CssBaseline />
       <App />
     </ThemeWithMediaProvider>

--- a/gluco-check-frontend/src/theme.ts
+++ b/gluco-check-frontend/src/theme.ts
@@ -1,6 +1,5 @@
 /* istanbul ignore file */
 import red from "@material-ui/core/colors/red";
-import orange from "@material-ui/core/colors/orange";
 import { ThemeOptions } from "@material-ui/core";
 import {
   amber,
@@ -8,7 +7,6 @@ import {
   deepOrange,
   grey,
   indigo,
-  lightBlue,
 } from "@material-ui/core/colors";
 
 export const lightThemeOptions: ThemeOptions = {
@@ -16,6 +14,7 @@ export const lightThemeOptions: ThemeOptions = {
     fontFamily: ["Poppins", "sans-serif"].join(","),
   },
   palette: {
+    type: "light",
     text: {
       primary: "#202124",
     },
@@ -24,14 +23,14 @@ export const lightThemeOptions: ThemeOptions = {
       contrastText: "#fff",
     },
     secondary: {
-      main: "#4285f4",
+      main: blue[700],
     },
     error: {
       main: red[500],
     },
     warning: {
-      light: "rgba(245, 124, 0, 0.75)", // orange[700] at 75%
-      main: orange[700],
+      light: "#d843154b", // deepOrange[800] at 75%
+      main: deepOrange[800],
     },
     background: {
       default: "#fff",
@@ -44,25 +43,26 @@ export const darkThemeOptions: ThemeOptions = {
     fontFamily: ["Poppins", "sans-serif"].join(","),
   },
   palette: {
+    type: "dark",
     text: {
-      primary: "#202124",
+      primary: indigo[50],
     },
     primary: {
-      main: "#1a73e8",
+      main: indigo[500],
       contrastText: "#fff",
     },
     secondary: {
       main: "#4285f4",
     },
     error: {
-      main: red[500],
+      main: red[300],
     },
     warning: {
-      light: "rgba(245, 124, 0, 0.75)", // orange[700] at 75%
-      main: orange[700],
+      light: "#ffca284b", // amber[400] at 75%
+      main: amber[400],
     },
     background: {
-      default: "#fff",
+      default: grey[900],
     },
   },
 };

--- a/gluco-check-frontend/src/theme.ts
+++ b/gluco-check-frontend/src/theme.ts
@@ -2,8 +2,44 @@
 import red from "@material-ui/core/colors/red";
 import orange from "@material-ui/core/colors/orange";
 import { ThemeOptions } from "@material-ui/core";
+import {
+  amber,
+  blue,
+  deepOrange,
+  grey,
+  indigo,
+  lightBlue,
+} from "@material-ui/core/colors";
 
-export const themeOptions: ThemeOptions = {
+export const lightThemeOptions: ThemeOptions = {
+  typography: {
+    fontFamily: ["Poppins", "sans-serif"].join(","),
+  },
+  palette: {
+    text: {
+      primary: "#202124",
+    },
+    primary: {
+      main: "#1a73e8",
+      contrastText: "#fff",
+    },
+    secondary: {
+      main: "#4285f4",
+    },
+    error: {
+      main: red[500],
+    },
+    warning: {
+      light: "rgba(245, 124, 0, 0.75)", // orange[700] at 75%
+      main: orange[700],
+    },
+    background: {
+      default: "#fff",
+    },
+  },
+};
+
+export const darkThemeOptions: ThemeOptions = {
   typography: {
     fontFamily: ["Poppins", "sans-serif"].join(","),
   },

--- a/gluco-check-frontend/src/theme.ts
+++ b/gluco-check-frontend/src/theme.ts
@@ -1,13 +1,7 @@
 /* istanbul ignore file */
 import red from "@material-ui/core/colors/red";
 import { ThemeOptions } from "@material-ui/core";
-import {
-  amber,
-  blue,
-  deepOrange,
-  grey,
-  indigo,
-} from "@material-ui/core/colors";
+import { amber, blue, grey, indigo, orange } from "@material-ui/core/colors";
 
 export const lightThemeOptions: ThemeOptions = {
   typography: {
@@ -29,8 +23,8 @@ export const lightThemeOptions: ThemeOptions = {
       main: red[500],
     },
     warning: {
-      light: "#d843154b", // deepOrange[800] at 75%
-      main: deepOrange[800],
+      light: "#e651004b", // deepOrange[800] at 75%
+      main: orange[900],
     },
     background: {
       default: "#fff",

--- a/gluco-check-frontend/src/theme.ts
+++ b/gluco-check-frontend/src/theme.ts
@@ -13,7 +13,7 @@ export const lightThemeOptions: ThemeOptions = {
       primary: "#202124",
     },
     primary: {
-      main: "#1a73e8",
+      main: indigo[500],
       contrastText: "#fff",
     },
     secondary: {


### PR DESCRIPTION
## Description
In this PR we are:
* fixing a bug in `ThemeWithMediaProvider` that was preventing palette colours from src/theme from being properly used
* updating the focused field label  and underline colours when in dark mode
* updating our shade of warning orange, and the shade of blue used for checkboxes, to fix contrast issue surfaced by an automated check

This PR also reverts the default colour back from `pink[400]` to a blue colour, was easier to control contrast for, and I am pretty sure the pink only made its way in as a result of the `ThemeWithMediaProvider` bug.

## Motivation and Context
* The frontend should be accessible
* `ThemeWithMediaProvider` should properly provide colours to the application

## How Has This Been Tested?
Tested for regressions with the unit test suite, tested for contrast with the WCAG color contrast analyzer browser extension.

## Additional context
### Light before and after
<img width="685" alt="Screen Shot 2021-04-25 at 2 00 12 PM" src="https://user-images.githubusercontent.com/607091/116003984-b3018780-a5ce-11eb-85ec-198217451688.png">
<img width="694" alt="Screen Shot 2021-04-25 at 1 59 52 PM" src="https://user-images.githubusercontent.com/607091/116003986-b4cb4b00-a5ce-11eb-9b62-23d9177fa4d3.png">

### Dark before and after...
<img width="689" alt="Screen Shot 2021-04-25 at 2 00 42 PM" src="https://user-images.githubusercontent.com/607091/116003994-c1e83a00-a5ce-11eb-8b79-5d80009a7cb9.png">
<img width="685" alt="Screen Shot 2021-04-25 at 2 00 32 PM" src="https://user-images.githubusercontent.com/607091/116003996-c3196700-a5ce-11eb-8da7-483f6dab4ca7.png">



## Types of changes
* Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've made my changes in a separate branch
- ~[ ] I've updated documentation, or created an issue to do so later~
- [x] My change is passing new and existing tests