### PR TITLE
Make crowdin [skip ci]

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,7 +19,7 @@ Screenshots, etc...
 * Breaking change (fix or feature that would cause existing functionality to not work as expected)
 
 ## Checklist:
-<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- Here are some things to consider before merging. You can add/remove items as you see fit. -->
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
 - [ ] I've made my changes in a separate branch
 - [ ] I've updated documentation, or created an issue to do so later

--- a/.github/crowdin.yml
+++ b/.github/crowdin.yml
@@ -1,4 +1,4 @@
-commit_message: " [Commit by Crowdin]"
+commit_message: "[skip ci] [Commit by Crowdin]"
 files:
   - source: /gluco-check-common/strings/en-US/*
     translation: /gluco-check-common/strings/%locale%/%original_file_name%

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test-build-deploy:
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
## Description
Adds a [skip ci] tag to crowdin commit messages, so we don't trigger CI builds on every new translation

## Motivation and Context
We can still trigger a CI build by editing a file in a PR. CI must still pass for PR to be mergeable 

## How Has This Been Tested?
N/A

## Types of changes
<!--- Delete lines that do not apply -->
* New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've made my changes in a separate branch
- [ ] My change is passing new and existing tests