### PR TITLE
feature/language-selector add ability to manually switch language to frontend

### DIFF
--- a/gluco-check-frontend/package.json
+++ b/gluco-check-frontend/package.json
@@ -15,6 +15,7 @@
     "i18next": "^20.2.1",
     "i18next-browser-languagedetector": "^6.1.0",
     "i18next-http-backend": "^1.2.1",
+    "material-ui-popup-state": "^1.8.3",
     "pure-react-carousel": "^1.27.6",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/gluco-check-frontend/public/locales/en/translation.json
+++ b/gluco-check-frontend/public/locales/en/translation.json
@@ -87,7 +87,8 @@
     "CarbsOnBoard": "carbs on board",
     "SensorAge": "sensor age",
     "CannulaAge": "cannula age",
-    "PumpBattery": "pump battery"
+    "PumpBattery": "pump battery",
+    "PumpReservoir": "pump reservoir"
   },
   "tokenDialog": {
     "title": "Generating a Nightscout token",

--- a/gluco-check-frontend/public/locales/en/translation.json
+++ b/gluco-check-frontend/public/locales/en/translation.json
@@ -125,5 +125,13 @@
       "image": "copy-token.png",
       "image_alt": ""
     }
+  },
+  "languageSelector": {
+    "buttonLabel": "Language",
+    "contribute": "Contribute Translations",
+    "availableLanguageLabels": {
+      "en": "English",
+      "nl": "Dutch"
+    }
   }
 }

--- a/gluco-check-frontend/public/locales/nl/translation.json
+++ b/gluco-check-frontend/public/locales/nl/translation.json
@@ -87,7 +87,8 @@
     "CarbsOnBoard": "koolhydraten aan boord",
     "SensorAge": "sensor leeftijd",
     "CannulaAge": "infusie set leeftijd",
-    "PumpBattery": "pompbatterij"
+    "PumpBattery": "pompbatterij",
+    "PumpReservoir": "pomp reservoir"
   },
   "tokenDialog": {
     "title": "Een Nightscout token aanmaken",

--- a/gluco-check-frontend/public/locales/nl/translation.json
+++ b/gluco-check-frontend/public/locales/nl/translation.json
@@ -125,5 +125,13 @@
       "image": "copy-token.png",
       "image_alt": ""
     }
+  },
+  "languageSelector": {
+    "buttonLabel": "[Language]",
+    "contribute": "[Contribute Translations]",
+    "availableLanguageLabels": {
+      "en": "[English]",
+      "nl": "[Dutch]"
+    }
   }
 }

--- a/gluco-check-frontend/src/App.test.tsx
+++ b/gluco-check-frontend/src/App.test.tsx
@@ -34,6 +34,15 @@ jest.mock("./pages/Landing.tsx", () => {
   };
 });
 
+jest.mock("./components/LanguageSelector.tsx", () => {
+  return {
+    __esModule: true,
+    default: () => {
+      return <div>LanguageSelector</div>;
+    },
+  };
+});
+
 jest.mock("./pages/Welcome.tsx", () => {
   return {
     __esModule: true,

--- a/gluco-check-frontend/src/App.test.tsx
+++ b/gluco-check-frontend/src/App.test.tsx
@@ -1,12 +1,9 @@
 import React from "react";
 import { render, cleanup } from "@testing-library/react";
 import { axe } from "jest-axe";
-import userEvent from "@testing-library/user-event";
-import { auth } from "./lib/firebase";
 import * as firebaseAuthHooks from "react-firebase-hooks/auth";
 import App from "./App";
 import { mockUser } from "./lib/__mocks__/firebase";
-import { act } from "react-dom/test-utils";
 
 jest.mock("./lib/firebase.ts", () => {
   return {
@@ -15,6 +12,20 @@ jest.mock("./lib/firebase.ts", () => {
     },
   };
 });
+
+const mockLanguage = "en";
+jest.mock("react-i18next", () => ({
+  useTranslation: () => {
+    return {
+      t: jest.fn().mockImplementation((i) => {
+        return i;
+      }),
+      i18n: {
+        language: mockLanguage,
+      },
+    };
+  },
+}));
 
 jest.mock("./pages/EditSettings.tsx", () => {
   return {

--- a/gluco-check-frontend/src/App.tsx
+++ b/gluco-check-frontend/src/App.tsx
@@ -1,7 +1,13 @@
 import React from "react";
 import { auth } from "./lib/firebase";
 import { useAuthState } from "react-firebase-hooks/auth";
-import { BrowserRouter as Router, Switch, Route, Link } from "react-router-dom";
+import {
+  BrowserRouter as Router,
+  Switch,
+  Route,
+  Link,
+  Redirect,
+} from "react-router-dom";
 import { getDocumentPathForUser } from "./lib/firebase-helpers";
 import { useTranslation } from "react-i18next";
 import {
@@ -69,7 +75,7 @@ const useStyles = makeStyles((theme) => ({
 export default function App() {
   const classes = useStyles();
   const [user, loading] = useAuthState(auth);
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const docPath = user ? getDocumentPathForUser(user) : ""; // TODO: we don't want this empty path to be possible, AND we want to auth protect any other authed routes
 
   let Content: React.ReactElement | null = null;
@@ -86,7 +92,7 @@ export default function App() {
       <Toolbar variant="regular" className={classes.toolbar}>
         <section className={classes.leftToolbar}>
           <Typography variant="h6" component="h1" className={classes.navTitle}>
-            <Link to="/">{t("title")}</Link>
+            <Link to={`/${i18n.language}`}>{t("title")}</Link>
           </Typography>
         </section>
         <section className={classes.rightToolbar}>
@@ -124,7 +130,7 @@ export default function App() {
   );
 
   const availableLanguageParams = Object.values(AvailableLanguage).join("|");
-  const localesParamString = `/:locale(${availableLanguageParams})?`;
+  const localesParamString = `/:locale(${availableLanguageParams})`;
 
   return (
     <div className={classes.root}>
@@ -133,6 +139,12 @@ export default function App() {
         <Container maxWidth="lg" className={classes.container}>
           <Paper variant="elevation" className={classes.surface}>
             <Switch>
+              <Redirect
+                exact
+                from="/settings"
+                to={`/${i18n.language}/settings`}
+              />
+              <Redirect exact from="/" to={`/${i18n.language}`} />
               {user && (
                 <Route path={`${localesParamString}/settings`}>
                   <FirebaseUserDocumentContext.Provider value={docPath}>

--- a/gluco-check-frontend/src/App.tsx
+++ b/gluco-check-frontend/src/App.tsx
@@ -123,6 +123,9 @@ export default function App() {
     </AppBar>
   );
 
+  const availableLanguageParams = Object.values(AvailableLanguage).join("|");
+  const localesParamString = `/:locale(${availableLanguageParams})?`;
+
   return (
     <div className={classes.root}>
       <Router>
@@ -131,13 +134,13 @@ export default function App() {
           <Paper variant="elevation" className={classes.surface}>
             <Switch>
               {user && (
-                <Route path="/settings">
+                <Route path={`${localesParamString}/settings`}>
                   <FirebaseUserDocumentContext.Provider value={docPath}>
                     <EditSettings />
                   </FirebaseUserDocumentContext.Provider>
                 </Route>
               )}
-              <Route path="/">{Content}</Route>
+              <Route path={`${localesParamString}/`}>{Content}</Route>
             </Switch>
           </Paper>
         </Container>

--- a/gluco-check-frontend/src/App.tsx
+++ b/gluco-check-frontend/src/App.tsx
@@ -16,10 +16,12 @@ import {
 import { GitHub, Help } from "@material-ui/icons";
 
 import Landing from "./pages/Landing";
+import LanguageSelector from "./components/LanguageSelector";
 import EditSettings from "./pages/EditSettings";
 import Welcome from "./pages/Welcome";
 import "./App.css";
 import { FAQS_URL, GLUCO_CHECK_GITHUB_URL } from "./lib/constants";
+import { AvailableLanguage } from "./lib/enums";
 
 export const FirebaseUserDocumentContext = React.createContext("");
 
@@ -89,6 +91,11 @@ export default function App() {
         </section>
         <section className={classes.rightToolbar}>
           <ul className={classes.nav}>
+            {Object.values(AvailableLanguage).length > 1 && (
+              <li>
+                <LanguageSelector />
+              </li>
+            )}
             <li>
               <IconButton
                 aria-label={t("navigation.faqs")}

--- a/gluco-check-frontend/src/__snapshots__/App.test.tsx.snap
+++ b/gluco-check-frontend/src/__snapshots__/App.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`App component renders the component when no user and no loading 1`] = `
           class="MuiTypography-root makeStyles-navTitle-24 MuiTypography-h6"
         >
           <a
-            href="/"
+            href="/en"
           >
             title
           </a>
@@ -126,7 +126,7 @@ exports[`App component renders the component when user loaded 1`] = `
           class="MuiTypography-root makeStyles-navTitle-16 MuiTypography-h6"
         >
           <a
-            href="/"
+            href="/en"
           >
             title
           </a>
@@ -235,7 +235,7 @@ exports[`App component renders the component when user loading 1`] = `
           class="MuiTypography-root makeStyles-navTitle-8 MuiTypography-h6"
         >
           <a
-            href="/"
+            href="/en"
           >
             title
           </a>

--- a/gluco-check-frontend/src/__snapshots__/App.test.tsx.snap
+++ b/gluco-check-frontend/src/__snapshots__/App.test.tsx.snap
@@ -30,6 +30,11 @@ exports[`App component renders the component when no user and no loading 1`] = `
           class="makeStyles-nav-22"
         >
           <li>
+            <div>
+              LanguageSelector
+            </div>
+          </li>
+          <li>
             <a
               aria-disabled="false"
               aria-label="navigation.faqs"
@@ -134,6 +139,11 @@ exports[`App component renders the component when user loaded 1`] = `
           class="makeStyles-nav-14"
         >
           <li>
+            <div>
+              LanguageSelector
+            </div>
+          </li>
+          <li>
             <a
               aria-disabled="false"
               aria-label="navigation.faqs"
@@ -237,6 +247,11 @@ exports[`App component renders the component when user loading 1`] = `
         <ul
           class="makeStyles-nav-6"
         >
+          <li>
+            <div>
+              LanguageSelector
+            </div>
+          </li>
           <li>
             <a
               aria-disabled="false"

--- a/gluco-check-frontend/src/components/LanguageSelector.test.tsx
+++ b/gluco-check-frontend/src/components/LanguageSelector.test.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { axe } from "jest-axe";
+import LanguageSelector from "./LanguageSelector";
+
+const mockLanguage = "en";
+const mockChangeLanauge = jest.fn();
+jest.mock("react-i18next", () => ({
+  useTranslation: () => {
+    return {
+      t: jest.fn().mockImplementation((i) => {
+        return i;
+      }),
+      i18n: {
+        language: jest.fn().mockReturnValue(mockLanguage),
+        changeLanguage: mockChangeLanauge,
+      },
+    };
+  },
+}));
+
+afterEach(() => {
+  jest.resetAllMocks();
+  cleanup();
+});
+
+describe("LanguageSelector component", () => {
+  it("renders the component, handles clicks and selections", async () => {
+    const { container } = render(<LanguageSelector />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it("handles clicks on button and language selections", async () => {
+    const { container } = render(<LanguageSelector />);
+
+    let button = await screen.getByLabelText("languageSelector.buttonLabel");
+    expect(button).toBeInTheDocument();
+    await button.focus();
+    await button.click();
+    expect(screen.getAllByRole("menuitem")[0]).toHaveFocus();
+
+    await screen.getAllByRole("menuitem")[1].click();
+    expect(mockChangeLanauge).toHaveBeenCalled();
+  });
+
+  it("Accessibility: has no axe violations", async () => {
+    const { container } = render(<LanguageSelector />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/gluco-check-frontend/src/components/LanguageSelector.test.tsx
+++ b/gluco-check-frontend/src/components/LanguageSelector.test.tsx
@@ -43,6 +43,24 @@ describe("LanguageSelector component", () => {
     expect(mockChangeLanauge).toHaveBeenCalled();
   });
 
+  it("launches the translation contributions url when that option is selected", async () => {
+    expect.assertions(2);
+    const windowOpenSpy = jest.spyOn(global.window, "open");
+    windowOpenSpy.mockImplementationOnce((url, target, features, replace) => {
+      expect(url).toMatchInlineSnapshot(`"https://translate.glucocheck.app"`);
+      return null;
+    });
+
+    const { container } = render(<LanguageSelector />);
+
+    let button = await screen.getByLabelText("languageSelector.buttonLabel");
+    await button.click();
+    const allMenuItems = screen.getAllByRole("menuitem");
+
+    await screen.getAllByRole("menuitem")[allMenuItems.length - 1].click();
+    expect(windowOpenSpy).toHaveBeenCalled();
+  });
+
   it("Accessibility: has no axe violations", async () => {
     const { container } = render(<LanguageSelector />);
     expect(await axe(container)).toHaveNoViolations();

--- a/gluco-check-frontend/src/components/LanguageSelector.test.tsx
+++ b/gluco-check-frontend/src/components/LanguageSelector.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { cleanup, render, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
 import LanguageSelector from "./LanguageSelector";
@@ -12,12 +11,20 @@ jest.mock("react-i18next", () => ({
         return i;
       }),
       i18n: {
-        language: jest.fn().mockReturnValue(mockLanguage),
+        language: mockLanguage,
         changeLanguage: mockChangeLanauge,
       },
     };
   },
 }));
+
+import { useHistory, useLocation } from "react-router-dom";
+jest.mock("react-router-dom", () => ({
+  useHistory: jest.fn(),
+  useLocation: jest.fn(),
+}));
+const mockUseHistory = useHistory as jest.Mock;
+const mockUseLocation = useLocation as jest.Mock;
 
 afterEach(() => {
   jest.resetAllMocks();
@@ -25,6 +32,17 @@ afterEach(() => {
 });
 
 describe("LanguageSelector component", () => {
+  const mockPathname = "/en/path";
+  const mockHistoryPush = jest.fn();
+
+  beforeEach(() => {
+    mockUseHistory.mockReturnValue({
+      push: mockHistoryPush,
+    });
+    mockUseLocation.mockReturnValue({
+      pathname: mockPathname,
+    });
+  });
   it("renders the component, handles clicks and selections", async () => {
     const { container } = render(<LanguageSelector />);
     expect(container.firstChild).toMatchSnapshot();
@@ -41,6 +59,7 @@ describe("LanguageSelector component", () => {
 
     await screen.getAllByRole("menuitem")[1].click();
     expect(mockChangeLanauge).toHaveBeenCalled();
+    expect(mockHistoryPush).toHaveBeenCalled();
   });
 
   it("launches the translation contributions url when that option is selected", async () => {

--- a/gluco-check-frontend/src/components/LanguageSelector.test.tsx
+++ b/gluco-check-frontend/src/components/LanguageSelector.test.tsx
@@ -33,22 +33,38 @@ afterEach(() => {
 
 describe("LanguageSelector component", () => {
   const mockPathname = "/en/path";
-  const mockHistoryPush = jest.fn();
+
+  const originalLocation = window.location;
 
   beforeEach(() => {
-    mockUseHistory.mockReturnValue({
-      push: mockHistoryPush,
-    });
     mockUseLocation.mockReturnValue({
       pathname: mockPathname,
     });
+
+    // @ts-ignore
+    delete window.location;
+    window.location = {
+      ...originalLocation,
+      assign: jest.fn(),
+    };
   });
+
+  afterEach(() => {
+    window.location = originalLocation;
+  });
+
   it("renders the component, handles clicks and selections", async () => {
     const { container } = render(<LanguageSelector />);
     expect(container.firstChild).toMatchSnapshot();
   });
 
   it("handles clicks on button and language selections", async () => {
+    expect.assertions(5);
+
+    window.location.assign = jest.fn().mockImplementationOnce((url) => {
+      expect(url).toMatchInlineSnapshot(`"/nl/path"`);
+    });
+
     const { container } = render(<LanguageSelector />);
 
     let button = await screen.getByLabelText("languageSelector.buttonLabel");
@@ -59,7 +75,7 @@ describe("LanguageSelector component", () => {
 
     await screen.getAllByRole("menuitem")[1].click();
     expect(mockChangeLanauge).toHaveBeenCalled();
-    expect(mockHistoryPush).toHaveBeenCalled();
+    expect(window.location.assign).toBeCalled();
   });
 
   it("launches the translation contributions url when that option is selected", async () => {

--- a/gluco-check-frontend/src/components/LanguageSelector.tsx
+++ b/gluco-check-frontend/src/components/LanguageSelector.tsx
@@ -16,6 +16,7 @@ import {
   bindMenu,
 } from "material-ui-popup-state/hooks";
 import { AvailableLanguage } from "../lib/enums";
+import { CONTRIBUTE_TRANSLATIONS } from "../lib/constants";
 
 const useStyles = makeStyles((theme) => ({
   selectorLabel: {
@@ -89,7 +90,7 @@ export default function LanguageSelector() {
           <Divider />
           <MenuItem
             onClick={() => {
-              window.open(t("urls.translations"), "_blank");
+              window.open(CONTRIBUTE_TRANSLATIONS, "_blank");
             }}
           >
             {t(`languageSelector.contribute`)}

--- a/gluco-check-frontend/src/components/LanguageSelector.tsx
+++ b/gluco-check-frontend/src/components/LanguageSelector.tsx
@@ -1,0 +1,101 @@
+import React from "react";
+import {
+  Button,
+  Divider,
+  Hidden,
+  makeStyles,
+  Menu,
+  MenuItem,
+  Paper,
+} from "@material-ui/core";
+import { ExpandMore, Translate } from "@material-ui/icons";
+import { useTranslation } from "react-i18next";
+import {
+  usePopupState,
+  bindTrigger,
+  bindMenu,
+} from "material-ui-popup-state/hooks";
+import { AvailableLanguage } from "../lib/enums";
+
+const useStyles = makeStyles((theme) => ({
+  selectorLabel: {
+    marginLeft: theme.spacing(1),
+    marginRight: theme.spacing(1),
+  },
+}));
+
+const MENU_ITEM_ATTRIBUTE = "data-language";
+
+export default function LanguageSelector() {
+  const { t, i18n } = useTranslation();
+
+  const classes = useStyles();
+
+  const menuState = usePopupState({
+    variant: "popover",
+    popupId: "languageMenu",
+  });
+
+  const handleItemClick = (
+    event: React.MouseEvent<HTMLLIElement, MouseEvent>
+  ) => {
+    const incomingSelection = event.currentTarget.getAttribute(
+      MENU_ITEM_ATTRIBUTE
+    );
+    if (
+      incomingSelection &&
+      Object.values(AvailableLanguage).includes(
+        incomingSelection as AvailableLanguage
+      )
+    ) {
+      i18n.changeLanguage(incomingSelection);
+    }
+
+    menuState.close();
+  };
+
+  return (
+    <div>
+      <Button
+        color="inherit"
+        {...bindTrigger(menuState)}
+        aria-label={t(`languageSelector.buttonLabel`)}
+      >
+        <Translate />
+        <Hidden xsDown>
+          <span className={classes.selectorLabel}>
+            {t(`languageSelector.buttonLabel`)}
+          </span>
+        </Hidden>
+        <ExpandMore />
+      </Button>
+      <Paper>
+        <Menu {...bindMenu(menuState)}>
+          {Object.values(AvailableLanguage).map((value, index) => {
+            const dataProp = {
+              [MENU_ITEM_ATTRIBUTE]: value,
+            };
+            return (
+              <MenuItem
+                key={`language-selector-${index}`}
+                onClick={handleItemClick}
+                selected={value === i18n.language}
+                {...dataProp}
+              >
+                {t(`languageSelector.availableLanguageLabels.${value}`)}
+              </MenuItem>
+            );
+          })}
+          <Divider />
+          <MenuItem
+            onClick={() => {
+              window.open(t("urls.translations"), "_blank");
+            }}
+          >
+            {t(`languageSelector.contribute`)}
+          </MenuItem>
+        </Menu>
+      </Paper>
+    </div>
+  );
+}

--- a/gluco-check-frontend/src/components/LanguageSelector.tsx
+++ b/gluco-check-frontend/src/components/LanguageSelector.tsx
@@ -17,7 +17,7 @@ import {
 } from "material-ui-popup-state/hooks";
 import { AvailableLanguage } from "../lib/enums";
 import { CONTRIBUTE_TRANSLATIONS } from "../lib/constants";
-import { useHistory, useLocation } from "react-router-dom";
+import { useLocation } from "react-router-dom";
 import { replaceLanguageInPathname } from "../lib/navigation";
 
 const useStyles = makeStyles((theme) => ({
@@ -32,7 +32,6 @@ const MENU_ITEM_ATTRIBUTE = "data-language";
 export default function LanguageSelector() {
   const { t, i18n } = useTranslation();
   const location = useLocation();
-  const history = useHistory();
 
   const classes = useStyles();
 
@@ -53,7 +52,7 @@ export default function LanguageSelector() {
         incomingSelection as AvailableLanguage
       )
     ) {
-      history.push(
+      window.location.assign(
         replaceLanguageInPathname(location.pathname, incomingSelection)
       );
       i18n.changeLanguage(incomingSelection);

--- a/gluco-check-frontend/src/components/LanguageSelector.tsx
+++ b/gluco-check-frontend/src/components/LanguageSelector.tsx
@@ -17,6 +17,8 @@ import {
 } from "material-ui-popup-state/hooks";
 import { AvailableLanguage } from "../lib/enums";
 import { CONTRIBUTE_TRANSLATIONS } from "../lib/constants";
+import { useHistory, useLocation } from "react-router-dom";
+import { replaceLanguageInPathname } from "../lib/navigation";
 
 const useStyles = makeStyles((theme) => ({
   selectorLabel: {
@@ -29,6 +31,8 @@ const MENU_ITEM_ATTRIBUTE = "data-language";
 
 export default function LanguageSelector() {
   const { t, i18n } = useTranslation();
+  const location = useLocation();
+  const history = useHistory();
 
   const classes = useStyles();
 
@@ -49,6 +53,9 @@ export default function LanguageSelector() {
         incomingSelection as AvailableLanguage
       )
     ) {
+      history.push(
+        replaceLanguageInPathname(location.pathname, incomingSelection)
+      );
       i18n.changeLanguage(incomingSelection);
     }
 

--- a/gluco-check-frontend/src/components/SettingsForm.test.tsx
+++ b/gluco-check-frontend/src/components/SettingsForm.test.tsx
@@ -114,15 +114,24 @@ describe("SettingsForm component", () => {
     expect(screen.getByTestId("settings-form")).toBeInTheDocument();
     const submitButton = await screen.findByTestId("settings-form-submit");
     const tokenField = await screen.findByTestId("settings-form-field-token");
-    const checkboxEverything = await screen.getByLabelText("everything", {
-      exact: false,
-    });
-    const checkbox1 = await screen.getByLabelText("insulin on board", {
-      exact: false,
-    });
-    const checkbox2 = await screen.getByLabelText("blood sugar", {
-      exact: false,
-    });
+    const checkboxEverything = await screen.getByLabelText(
+      "DiabetesMetrics.Everything",
+      {
+        exact: false,
+      }
+    );
+    const checkbox1 = await screen.getByLabelText(
+      "DiabetesMetrics.InsulinOnBoard",
+      {
+        exact: false,
+      }
+    );
+    const checkbox2 = await screen.getByLabelText(
+      "DiabetesMetrics.BloodSugar",
+      {
+        exact: false,
+      }
+    );
 
     await act(async () => {
       await userEvent.click(checkboxEverything);

--- a/gluco-check-frontend/src/components/SettingsForm.tsx
+++ b/gluco-check-frontend/src/components/SettingsForm.tsx
@@ -527,7 +527,7 @@ export default function SettingsForm({
                       />
                     }
                     key={metric.value}
-                    label={metric.value}
+                    label={t(metric.label)}
                   />
                 );
               });

--- a/gluco-check-frontend/src/components/__snapshots__/LanguageSelector.test.tsx.snap
+++ b/gluco-check-frontend/src/components/__snapshots__/LanguageSelector.test.tsx.snap
@@ -1,0 +1,44 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LanguageSelector component renders the component, handles clicks and selections 1`] = `
+<div>
+  <button
+    aria-haspopup="true"
+    aria-label="languageSelector.buttonLabel"
+    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-colorInherit"
+    tabindex="0"
+    type="button"
+  >
+    <span
+      class="MuiButton-label"
+    >
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M12.87 15.07l-2.54-2.51.03-.03c1.74-1.94 2.98-4.17 3.71-6.53H17V4h-7V2H8v2H1v1.99h11.17C11.5 7.92 10.44 9.75 9 11.35 8.07 10.32 7.3 9.19 6.69 8h-2c.73 1.63 1.73 3.17 2.98 4.56l-5.09 5.02L4 19l5-5 3.11 3.11.76-2.04zM18.5 10h-2L12 22h2l1.12-3h4.75L21 22h2l-4.5-12zm-2.62 7l1.62-4.33L19.12 17h-3.24z"
+        />
+      </svg>
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+        />
+      </svg>
+    </span>
+    <span
+      class="MuiTouchRipple-root"
+    />
+  </button>
+  <div
+    class="MuiPaper-root MuiPaper-elevation1 MuiPaper-rounded"
+  />
+</div>
+`;

--- a/gluco-check-frontend/src/components/__snapshots__/SettingsForm.test.tsx.snap
+++ b/gluco-check-frontend/src/components/__snapshots__/SettingsForm.test.tsx.snap
@@ -123,7 +123,7 @@ exports[`SettingsForm component renders the component 1`] = `
         <span
           class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
         >
-          everything
+          diabetesMetrics.Everything
         </span>
       </label>
       <label
@@ -161,7 +161,7 @@ exports[`SettingsForm component renders the component 1`] = `
         <span
           class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
         >
-          blood sugar
+          diabetesMetrics.BloodSugar
         </span>
       </label>
       <label
@@ -198,7 +198,7 @@ exports[`SettingsForm component renders the component 1`] = `
         <span
           class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
         >
-          insulin on board
+          diabetesMetrics.InsulinOnBoard
         </span>
       </label>
       <label
@@ -235,7 +235,7 @@ exports[`SettingsForm component renders the component 1`] = `
         <span
           class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
         >
-          carbs on board
+          diabetesMetrics.CarbsOnBoard
         </span>
       </label>
       <label
@@ -272,7 +272,7 @@ exports[`SettingsForm component renders the component 1`] = `
         <span
           class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
         >
-          sensor age
+          diabetesMetrics.SensorAge
         </span>
       </label>
       <label
@@ -309,7 +309,7 @@ exports[`SettingsForm component renders the component 1`] = `
         <span
           class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
         >
-          cannula age
+          diabetesMetrics.CannulaAge
         </span>
       </label>
       <label
@@ -346,7 +346,7 @@ exports[`SettingsForm component renders the component 1`] = `
         <span
           class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
         >
-          pump battery
+          diabetesMetrics.PumpBattery
         </span>
       </label>
       <label
@@ -383,7 +383,7 @@ exports[`SettingsForm component renders the component 1`] = `
         <span
           class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
         >
-          pump reservoir
+          diabetesMetrics.PumpReservoir
         </span>
       </label>
     </div>

--- a/gluco-check-frontend/src/lib/constants.ts
+++ b/gluco-check-frontend/src/lib/constants.ts
@@ -26,5 +26,6 @@ export const NIGHTSCOUT_PROJECT_URL = "http://nightscout.info/";
 export const FAQS_URL = "/faq";
 export const GLUCO_CHECK_GITHUB_URL =
   "https://github.com/nielsmaerten/gluco-check";
+export const CONTRIBUTE_TRANSLATIONS = "https://translate.glucocheck.app";
 
 export const APP_DEBUG = process.env.REACT_APP_DEBUG === "true" || false;

--- a/gluco-check-frontend/src/lib/enums.ts
+++ b/gluco-check-frontend/src/lib/enums.ts
@@ -22,3 +22,8 @@ export enum DiabetesMetric {
   PumpBattery = "pump battery",
   PumpReservoir = "pump reservoir",
 }
+
+export enum AvailableLanguage {
+  English = "en",
+  Dutch = "nl",
+}

--- a/gluco-check-frontend/src/lib/i18n.ts
+++ b/gluco-check-frontend/src/lib/i18n.ts
@@ -3,6 +3,7 @@ import i18n from "i18next";
 import Backend from "i18next-http-backend";
 import { initReactI18next } from "react-i18next";
 import LanguageDetector from "i18next-browser-languagedetector";
+import { AvailableLanguage } from "./enums";
 
 i18n
   .use(Backend)
@@ -10,7 +11,7 @@ i18n
   .use(initReactI18next)
   .init({
     fallbackLng: (code) => {
-      const fallback = process.env.REACT_APP_I18N_FALLBACK_LANGUAGE || "en-US";
+      const fallback = process.env.REACT_APP_I18N_FALLBACK_LANGUAGE || "en";
       return [fallback];
     },
     detection: {
@@ -21,6 +22,7 @@ i18n
     interpolation: {
       escapeValue: false,
     },
+    supportedLngs: Object.values(AvailableLanguage),
   });
 
 i18n.on("languageChanged", (lng) => {

--- a/gluco-check-frontend/src/lib/i18n.ts
+++ b/gluco-check-frontend/src/lib/i18n.ts
@@ -14,16 +14,8 @@ i18n
       return [fallback];
     },
     detection: {
-      order: [
-        "querystring",
-        "navigator",
-        "cookie",
-        "localStorage",
-        "sessionStorage",
-        "htmlTag",
-        "path",
-        "subdomain",
-      ],
+      order: ["path", "querystring", "navigator"],
+      lookupFromPathIndex: 0,
     },
     debug: process.env.REACT_APP_I18N_DEBUG === "true" || false,
     interpolation: {

--- a/gluco-check-frontend/src/lib/i18n.ts
+++ b/gluco-check-frontend/src/lib/i18n.ts
@@ -14,10 +14,9 @@ i18n
       return [fallback];
     },
     detection: {
-      // this is just the defaults with navigator moved to the front of the line
       order: [
-        "navigator",
         "querystring",
+        "navigator",
         "cookie",
         "localStorage",
         "sessionStorage",

--- a/gluco-check-frontend/src/lib/navigation.test.ts
+++ b/gluco-check-frontend/src/lib/navigation.test.ts
@@ -1,0 +1,18 @@
+import { replaceLanguageInPathname } from "./navigation";
+
+describe("route helper methods", () => {
+  const mockSupportedLanguages = ["en", "nl"];
+  it.each`
+    route             | newLanguage | newRoute
+    ${`/en/settings`} | ${`nl`}     | ${`/nl/settings`}
+    ${`/en`}          | ${`nl`}     | ${`/nl`}
+    ${`/en/settings`} | ${`fr`}     | ${`/en/settings`}
+  `(
+    "$route called with $newLanguage should yield $newRoute",
+    ({ route, newLanguage, newRoute }) => {
+      expect(
+        replaceLanguageInPathname(route, newLanguage, mockSupportedLanguages)
+      ).toEqual(newRoute);
+    }
+  );
+});

--- a/gluco-check-frontend/src/lib/navigation.ts
+++ b/gluco-check-frontend/src/lib/navigation.ts
@@ -1,0 +1,17 @@
+import { AvailableLanguage } from "./enums";
+
+const LANGUAGE_INDEX = 1;
+const SLASH = "/";
+
+export const replaceLanguageInPathname = (
+  pathname: string,
+  newLanguage: string,
+  supportedLanguages: string[] = Object.values(AvailableLanguage)
+) => {
+  const splitRoute = pathname.split(SLASH);
+  if (supportedLanguages.includes(newLanguage)) {
+    splitRoute[LANGUAGE_INDEX] = newLanguage;
+    return splitRoute.join(SLASH);
+  }
+  return pathname;
+};

--- a/gluco-check-frontend/src/pages/Landing.test.tsx
+++ b/gluco-check-frontend/src/pages/Landing.test.tsx
@@ -13,6 +13,20 @@ jest.mock("react-i18next", () => ({
   },
 }));
 
+const mockLanguage = "en";
+jest.mock("react-i18next", () => ({
+  useTranslation: () => {
+    return {
+      t: jest.fn().mockImplementation((i) => {
+        return i;
+      }),
+      i18n: {
+        language: mockLanguage,
+      },
+    };
+  },
+}));
+
 jest.mock("../lib/firebase");
 jest.mock("react-firebaseui/StyledFirebaseAuth", () => {
   return {

--- a/gluco-check-frontend/src/pages/Landing.tsx
+++ b/gluco-check-frontend/src/pages/Landing.tsx
@@ -64,6 +64,7 @@ function Landing() {
       },
     ],
     callbacks: {
+      /* istanbul ignore next */
       signInSuccessWithAuthResult: () => {
         /* istanbul ignore next */
         return false;

--- a/gluco-check-frontend/src/pages/Landing.tsx
+++ b/gluco-check-frontend/src/pages/Landing.tsx
@@ -49,18 +49,23 @@ const useStyles = makeStyles((theme) => ({
 
 function Landing() {
   const classes = useStyles();
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+
+  const loginButtonLabel = t("login.buttonLabel");
 
   const firebaseUIConfig = {
     credentialHelper: firebaseui.auth.CredentialHelper.NONE,
     signInFlow: "redirect",
-    signInSuccessUrl: "/",
+    signInSuccessUrl: `/${i18n.language}`,
     signInOptions: [
       {
         provider: firebase.auth.GoogleAuthProvider.PROVIDER_ID,
-        fullLabel: t("login.buttonLabel"),
+        fullLabel: loginButtonLabel,
       },
     ],
+    callbacks: {
+      signInSuccessWithAuthResult: () => false,
+    },
   };
 
   return (

--- a/gluco-check-frontend/src/pages/Landing.tsx
+++ b/gluco-check-frontend/src/pages/Landing.tsx
@@ -64,7 +64,10 @@ function Landing() {
       },
     ],
     callbacks: {
-      signInSuccessWithAuthResult: () => false,
+      signInSuccessWithAuthResult: () => {
+        /* istanbul ignore next */
+        return false;
+      },
     },
   };
 

--- a/gluco-check-frontend/src/pages/Welcome.test.tsx
+++ b/gluco-check-frontend/src/pages/Welcome.test.tsx
@@ -3,12 +3,16 @@ import { cleanup, render } from "@testing-library/react";
 import { axe } from "jest-axe";
 import Welcome, { handleSignoutClicked } from "./Welcome";
 
+const mockLanguage = "en";
 jest.mock("react-i18next", () => ({
   useTranslation: () => {
     return {
       t: jest.fn().mockImplementation((i) => {
         return i;
       }),
+      i18n: {
+        language: mockLanguage,
+      },
     };
   },
   Trans: function (props: any) {

--- a/gluco-check-frontend/src/pages/Welcome.tsx
+++ b/gluco-check-frontend/src/pages/Welcome.tsx
@@ -63,7 +63,7 @@ const useStyles = makeStyles((theme) => ({
 
 function Welcome() {
   const classes = useStyles();
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
 
   return (
     <Grid
@@ -86,7 +86,11 @@ function Welcome() {
         <Onboarding />
       </Grid>
       <Grid item>
-        <Button variant="contained" color="primary" href="/settings">
+        <Button
+          variant="contained"
+          color="primary"
+          href={`/${i18n.language}/settings`}
+        >
           {t("welcome.cta")}
         </Button>
       </Grid>

--- a/gluco-check-frontend/src/pages/Welcome.tsx
+++ b/gluco-check-frontend/src/pages/Welcome.tsx
@@ -10,6 +10,7 @@ import {
 import Onboarding from "../components/Onboarding";
 import Boilerplate from "../components/Boilerplate";
 import { auth } from "../lib/firebase";
+import { useHistory } from "react-router-dom";
 
 export const handleSignoutClicked = () => {
   auth.signOut();
@@ -64,6 +65,7 @@ const useStyles = makeStyles((theme) => ({
 function Welcome() {
   const classes = useStyles();
   const { t, i18n } = useTranslation();
+  const history = useHistory();
 
   return (
     <Grid
@@ -89,7 +91,10 @@ function Welcome() {
         <Button
           variant="contained"
           color="primary"
-          href={`/${i18n.language}/settings`}
+          data-testid="settings-button"
+          onClick={() => {
+            history.push(`/${i18n.language}/settings`);
+          }}
         >
           {t("welcome.cta")}
         </Button>

--- a/gluco-check-frontend/src/pages/__snapshots__/Welcome.test.tsx.snap
+++ b/gluco-check-frontend/src/pages/__snapshots__/Welcome.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`Welcome page renders the component 1`] = `
     <a
       aria-disabled="false"
       class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
-      href="/settings"
+      href="/en/settings"
       tabindex="0"
     >
       <span

--- a/gluco-check-frontend/src/pages/__snapshots__/Welcome.test.tsx.snap
+++ b/gluco-check-frontend/src/pages/__snapshots__/Welcome.test.tsx.snap
@@ -25,11 +25,11 @@ exports[`Welcome page renders the component 1`] = `
   <div
     class="MuiGrid-root MuiGrid-item"
   >
-    <a
-      aria-disabled="false"
+    <button
       class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
-      href="/en/settings"
+      data-testid="settings-button"
       tabindex="0"
+      type="button"
     >
       <span
         class="MuiButton-label"
@@ -38,8 +38,17 @@ exports[`Welcome page renders the component 1`] = `
       </span>
       <span
         class="MuiTouchRipple-root"
-      />
-    </a>
+      >
+        <span
+          class="MuiTouchRipple-ripple MuiTouchRipple-rippleVisible"
+          style="width: 2.8284271247461903px; height: 2.8284271247461903px; top: -1.4142135623730951px; left: -1.4142135623730951px;"
+        >
+          <span
+            class="MuiTouchRipple-child MuiTouchRipple-childLeaving"
+          />
+        </span>
+      </span>
+    </button>
   </div>
   <div
     class="MuiGrid-root makeStyles-boilerplate-5 MuiGrid-item"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2838,6 +2838,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@material-ui/types@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "@material-ui/types@npm:4.1.1"
+  dependencies:
+    "@types/react": "*"
+  checksum: b5ee63a8967e2209a24ce3ddde103e54e6dd75b0ffbd35307ac90a32807bc322b50ff781c3add447b547f8a0ae90c06e9c87da8278e5cd31f6a2b6f0a06f46b0
+  languageName: node
+  linkType: hard
+
 "@material-ui/types@npm:^5.1.0":
   version: 5.1.7
   resolution: "@material-ui/types@npm:5.1.7"
@@ -6095,6 +6104,13 @@ __metadata:
     libphonenumber-js: ^1.9.7
     validator: ^13.5.2
   checksum: 09a7d83213ac40b2c57502790701277b323f0977d0e1d5597c1a5a0990a8c9ee04ab75b8e2395a39063c0ee9dd196e1cb900a420ff5808b8a1923de2b8c705fe
+  languageName: node
+  linkType: hard
+
+"classnames@npm:^2.2.6":
+  version: 2.3.1
+  resolution: "classnames@npm:2.3.1"
+  checksum: 57d536edede609f81425d24b062d8d720a466565faf1e38d32c881e883920baa71519ac70c7b565e9cd39201fb1c1ff9bdf8aabf8e26544bac481e7924867c83
   languageName: node
   linkType: hard
 
@@ -9722,6 +9738,7 @@ fsevents@^2.1.2:
     jest-axe: ^4.1.0
     jest-fetch-mock: ^3.0.3
     lint-staged: ^10.5.4
+    material-ui-popup-state: ^1.8.3
     mutationobserver-shim: ^0.3.7
     prettier: ^2.2.1
     pure-react-carousel: ^1.27.6
@@ -12972,6 +12989,20 @@ fsevents@^2.1.2:
   version: 1.3.0
   resolution: "material-design-lite@npm:1.3.0"
   checksum: a5cfea3c6af6f2d9891ce41c148e1588de2932d52e0a65da63079967ff59ae286e6c7761263e87cf1bcb8e5b87c473d0082bea9f20e6d367851089cefce56050
+  languageName: node
+  linkType: hard
+
+"material-ui-popup-state@npm:^1.8.3":
+  version: 1.8.3
+  resolution: "material-ui-popup-state@npm:1.8.3"
+  dependencies:
+    "@babel/runtime": ^7.12.5
+    "@material-ui/types": ^4.1.1
+    classnames: ^2.2.6
+    prop-types: ^15.7.2
+  peerDependencies:
+    react: ^15.0.0 || ^16.0.0 || ^17.0.0
+  checksum: d05f14c9633849d6438d2ba47d2ae23727b6895fcde000d2298b70a18fe904d5fcb99a800de1a4af497714eb24cf6503aeb0a3ca2c6db0a8c0d8d9ed74053b5e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description
In this PR we are adding a means to manually select the language for the frontend by:
* adding a new language selector component as a drop-down menu
* adding translation strings to support the menu
* adding a "supported languages" enum that the frontend uses as the actual source of truth for what languages are available (context: because loading translations via i18n-http-backend doesn't allow the frontend to have inherent awareness of what translations are available, for now we include a separate means to make this information available)

## Motivation and Context
This work was already near to completion in the old frontend repo, and thanks to @nielsmaerten contributing the remaining Dutch strings, we now have two translations for the frontend, so let's make them available and get this work completed.

## How Has This Been Tested?
Manually tested, unit tested.

## Additional context
<img width="278" alt="Screen Shot 2021-05-01 at 3 44 39 PM" src="https://user-images.githubusercontent.com/607091/116793324-2d7d4c00-aa94-11eb-8eea-00d8919d68c3.png">
Above, at greater-than-mobile width, the selector is displayed with a label, while on mobile it collapses to just the icon and chevron...
<img width="324" alt="Screen Shot 2021-05-01 at 3 44 12 PM" src="https://user-images.githubusercontent.com/607091/116793346-4b4ab100-aa94-11eb-911e-cd538f113381.png">
<img width="325" alt="Screen Shot 2021-05-01 at 3 44 18 PM" src="https://user-images.githubusercontent.com/607091/116793347-4be34780-aa94-11eb-8e55-bdaee1e5714a.png">


## Types of changes
* New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Here are some things to consider before merging. You can add/remove items as you see fit. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've made my changes in a separate branch
- [ ] I've updated documentation, or created an issue to do so later
- [x] My change is passing new and existing tests