### PR TITLE
Minor style adjustments

### DIFF
--- a/gluco-check-frontend/src/App.tsx
+++ b/gluco-check-frontend/src/App.tsx
@@ -47,6 +47,7 @@ const useStyles = makeStyles((theme) => ({
   surface: {
     padding: theme.spacing(2),
     marginBottom: theme.spacing(2),
+    marginTop: theme.spacing(2),
   },
   leftToolbar: {},
   rightToolbar: {
@@ -136,7 +137,7 @@ export default function App() {
     <div className={classes.root}>
       <Router>
         {navigation}
-        <Container maxWidth="lg" className={classes.container}>
+        <Container maxWidth="md" className={classes.container}>
           <Paper variant="elevation" className={classes.surface}>
             <Switch>
               <Redirect

--- a/gluco-check-frontend/src/__snapshots__/App.test.tsx.snap
+++ b/gluco-check-frontend/src/__snapshots__/App.test.tsx.snap
@@ -96,7 +96,7 @@ exports[`App component renders the component when no user and no loading 1`] = `
     </div>
   </header>
   <div
-    class="MuiContainer-root makeStyles-container-18 MuiContainer-maxWidthLg"
+    class="MuiContainer-root makeStyles-container-18 MuiContainer-maxWidthMd"
   >
     <div
       class="MuiPaper-root makeStyles-surface-19 MuiPaper-elevation1 MuiPaper-rounded"
@@ -205,7 +205,7 @@ exports[`App component renders the component when user loaded 1`] = `
     </div>
   </header>
   <div
-    class="MuiContainer-root makeStyles-container-10 MuiContainer-maxWidthLg"
+    class="MuiContainer-root makeStyles-container-10 MuiContainer-maxWidthMd"
   >
     <div
       class="MuiPaper-root makeStyles-surface-11 MuiPaper-elevation1 MuiPaper-rounded"
@@ -314,7 +314,7 @@ exports[`App component renders the component when user loading 1`] = `
     </div>
   </header>
   <div
-    class="MuiContainer-root makeStyles-container-2 MuiContainer-maxWidthLg"
+    class="MuiContainer-root makeStyles-container-2 MuiContainer-maxWidthMd"
   >
     <div
       class="MuiPaper-root makeStyles-surface-3 MuiPaper-elevation1 MuiPaper-rounded"

--- a/gluco-check-frontend/src/components/Boilerplate.tsx
+++ b/gluco-check-frontend/src/components/Boilerplate.tsx
@@ -19,6 +19,9 @@ const useStyles = makeStyles((theme) => ({
       textDecoration: "underline",
     },
   },
+  signOut: {
+    cursor: "pointer",
+  },
 }));
 
 type BoilerplateProps = {
@@ -33,7 +36,12 @@ function Boilerplate({ handleSignoutClicked }: BoilerplateProps) {
     <>
       <Typography>
         {handleSignoutClicked && (
-          <Link variant="body2" color="error" onClick={handleSignoutClicked}>
+          <Link
+            variant="body2"
+            color="error"
+            onClick={handleSignoutClicked}
+            className={classes.signOut}
+          >
             {t("boilerplate.logout")}
           </Link>
         )}

--- a/gluco-check-frontend/src/components/__snapshots__/Boilerplate.test.tsx.snap
+++ b/gluco-check-frontend/src/components/__snapshots__/Boilerplate.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`Landing page renders the component 1`] = `
   class="MuiTypography-root MuiTypography-body1"
 >
   <a
-    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-body2 MuiTypography-colorError"
+    class="MuiTypography-root MuiLink-root MuiLink-underlineHover makeStyles-signOut-2 MuiTypography-body2 MuiTypography-colorError"
   >
     boilerplate.logout
   </a>


### PR DESCRIPTION
## Description
This PR makes a few small styling adjustments that I've been meaning to make:
* reduces maxwidth of global container, matching the max width of the settings form
* moves global `Paper` container out from under appbar
* updates signout button to use `cursor: pointer` so that it behaves like a standard clickable element

## Motivation and Context
Improves layout of settings page; improves legibility of signout button as an action.

## How Has This Been Tested?
Manually, and unit tests.

## Types of changes
* New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Here are some things to consider before merging. You can add/remove items as you see fit. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've made my changes in a separate branch
- ~[ ] I've updated documentation, or created an issue to do so later~
- [x] My change is passing new and existing tests