### PR TITLE
fix: Sensor was inserted NaN years ago

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -74,7 +74,7 @@ jobs:
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-yarn-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
 

--- a/gluco-check-core/src/main/clients/nightscout/NightscoutClient.ts
+++ b/gluco-check-core/src/main/clients/nightscout/NightscoutClient.ts
@@ -55,7 +55,7 @@ export default class NightscoutClient {
       logger.debug(logTag, `HTTP request: ${path} (cached)`);
     }
 
-    // ...No: send HTTP request
+    // ...No: prepare HTTP request
     else {
       logger.debug(logTag, 'HTTP request:', path);
       const request: AxiosRequestConfig = {

--- a/gluco-check-core/src/main/clients/nightscout/queries/CannulaAge.ts
+++ b/gluco-check-core/src/main/clients/nightscout/queries/CannulaAge.ts
@@ -8,7 +8,7 @@ export const CannulaAge: QueryConfig = {
   params: {eventType: 'Site Change', sort$desc: 'created_at', limit: 1},
   callback: (data: any) => { // eslint-disable-line
     return {
-      cannulaInserted: new Date(data.created_at).getTime(),
+      cannulaInserted: new Date(data.created_at).getTime() || null,
     };
   },
 };

--- a/gluco-check-core/src/main/clients/nightscout/queries/CarbsInsulinOnBoard.ts
+++ b/gluco-check-core/src/main/clients/nightscout/queries/CarbsInsulinOnBoard.ts
@@ -10,7 +10,7 @@ export const CarbsInsulinOnBoard: QueryConfig = {
     return {
       carbsOnBoard: data.bgs[0]?.cob,
       insulinOnBoard: data.bgs[0]?.iob,
-      timestamp: new Date(data.bgs[0]?.datetime).getTime(),
+      timestamp: new Date(data.bgs[0]?.datetime).getTime() || null,
     };
   },
 };

--- a/gluco-check-core/src/main/clients/nightscout/queries/PumpStatus.ts
+++ b/gluco-check-core/src/main/clients/nightscout/queries/PumpStatus.ts
@@ -10,7 +10,7 @@ export const PumpStatus: QueryConfig = {
     return {
       pumpBattery: data.pump?.battery?.percent,
       pumpReservoir: data.pump?.reservoir,
-      timestamp: new Date(data.created_at).getTime(),
+      timestamp: new Date(data.created_at).getTime() || null,
     };
   },
 };

--- a/gluco-check-core/src/main/clients/nightscout/queries/SensorAge.ts
+++ b/gluco-check-core/src/main/clients/nightscout/queries/SensorAge.ts
@@ -8,7 +8,7 @@ export const SensorAge: QueryConfig = {
   params: {eventType: 'Sensor Change', sort$desc: 'created_at', limit: 1},
   callback: (data: any) => { // eslint-disable-line
     return {
-      sensorInserted: new Date(data.created_at).getTime(),
+      sensorInserted: new Date(data.created_at).getTime() || null,
     };
   },
 };

--- a/gluco-check-core/src/main/i18n/humanizers/BloodSugar.ts
+++ b/gluco-check-core/src/main/i18n/humanizers/BloodSugar.ts
@@ -6,16 +6,16 @@ import {i18next} from '..';
 import {formatNumber, translateTimestamp} from './_common';
 
 export default async function (params: FormatParams): Promise<string> {
+  if (!params.snapshot.glucoseValue()) {
+    return metricNotFound(DmMetric.BloodSugar, params);
+  }
+
   // Collect translation context
   const context = {
     value: formatNumber(params.snapshot.glucoseValue(), params.locale),
     trend: translateTrend(params.locale, params.snapshot.glucoseTrend),
     time: await translateTimestamp(params.snapshot.timestamp, params.locale),
   };
-
-  if (context.value === undefined) {
-    return metricNotFound(DmMetric.BloodSugar, params);
-  }
 
   // Build translation key
   let key = 'assistant_responses.blood_sugar.';

--- a/gluco-check-core/src/main/i18n/humanizers/CannulaAge.ts
+++ b/gluco-check-core/src/main/i18n/humanizers/CannulaAge.ts
@@ -5,12 +5,14 @@ import {metricNotFound} from './_error';
 import {DmMetric} from '../../../types/DmMetric';
 
 export default async function (params: FormatParams): Promise<string> {
+  if (!params.snapshot.cannulaInserted) {
+    return metricNotFound(DmMetric.CannulaAge, params);
+  }
+
   // Collect translation context
   const context = {
     time: await translateTimestamp(params.snapshot.cannulaInserted!, params.locale),
   };
-
-  if (!context.time) return metricNotFound(DmMetric.CannulaAge, params);
 
   // Build translation key
   const key = 'assistant_responses.cannula_age';

--- a/gluco-check-core/src/main/i18n/humanizers/CarbsOnBoard.ts
+++ b/gluco-check-core/src/main/i18n/humanizers/CarbsOnBoard.ts
@@ -5,13 +5,15 @@ import {metricNotFound} from './_error';
 import {DmMetric} from '../../../types/DmMetric';
 
 export default async function (params: FormatParams): Promise<string> {
+  if (!params.snapshot.carbsOnBoard) {
+    return metricNotFound(DmMetric.CarbsOnBoard, params);
+  }
+
   // Collect translation context
   const context = {
     value: formatNumber(params.snapshot.carbsOnBoard, params.locale),
     time: await translateTimestamp(params.snapshot.timestamp, params.locale),
   };
-
-  if (context.value === undefined) return metricNotFound(DmMetric.CarbsOnBoard, params);
 
   // Build translation key
   let key = 'assistant_responses.carbs_on_board.';

--- a/gluco-check-core/src/main/i18n/humanizers/InsulinOnBoard.ts
+++ b/gluco-check-core/src/main/i18n/humanizers/InsulinOnBoard.ts
@@ -5,13 +5,15 @@ import {metricNotFound} from './_error';
 import {DmMetric} from '../../../types/DmMetric';
 
 export default async function (params: FormatParams): Promise<string> {
+  if (!params.snapshot.insulinOnBoard) {
+    return metricNotFound(DmMetric.InsulinOnBoard, params);
+  }
+
   // Collect translation context
   const context = {
     value: formatNumber(params.snapshot.insulinOnBoard, params.locale),
     time: await translateTimestamp(params.snapshot.timestamp, params.locale),
   };
-
-  if (context.value === undefined) return metricNotFound(DmMetric.InsulinOnBoard, params);
 
   // Build translation key
   let key = 'assistant_responses.insulin_on_board.';

--- a/gluco-check-core/src/main/i18n/humanizers/PumpBattery.ts
+++ b/gluco-check-core/src/main/i18n/humanizers/PumpBattery.ts
@@ -5,12 +5,14 @@ import {DmMetric} from '../../../types/DmMetric';
 import {formatNumber} from './_common';
 
 export default async function (params: FormatParams): Promise<string> {
+  if (!params.snapshot.pumpBattery) {
+    return metricNotFound(DmMetric.PumpBattery, params);
+  }
+
   // Collect translation context
   const context = {
     percent: formatNumber(params.snapshot.pumpBattery, params.locale, 0, 'percent'),
   };
-
-  if (context.percent === undefined) return metricNotFound(DmMetric.PumpBattery, params);
 
   // Build translation key
   const key = 'assistant_responses.pump_battery';

--- a/gluco-check-core/src/main/i18n/humanizers/PumpReservoir.ts
+++ b/gluco-check-core/src/main/i18n/humanizers/PumpReservoir.ts
@@ -5,13 +5,14 @@ import {DmMetric} from '../../../types/DmMetric';
 import FormatParams from '../../../types/FormatParams';
 
 export default async function (params: FormatParams): Promise<string> {
+  if (!params.snapshot.pumpReservoir) {
+    return metricNotFound(DmMetric.PumpReservoir, params);
+  }
+
   // Collect translation context
   const context = {
     reservoir: formatNumber(params.snapshot.pumpReservoir, params.locale, 0),
   };
-
-  if (context.reservoir === undefined)
-    return metricNotFound(DmMetric.PumpReservoir, params);
 
   // Build translation key
   const key = 'assistant_responses.pump_reservoir';

--- a/gluco-check-core/src/main/i18n/humanizers/SensorAge.ts
+++ b/gluco-check-core/src/main/i18n/humanizers/SensorAge.ts
@@ -5,12 +5,14 @@ import {metricNotFound} from './_error';
 import {DmMetric} from '../../../types/DmMetric';
 
 export default async function (params: FormatParams): Promise<string> {
+  if (!params.snapshot.sensorInserted) {
+    return metricNotFound(DmMetric.SensorAge, params);
+  }
+
   // Collect translation context
   const context = {
     time: await translateTimestamp(params.snapshot.sensorInserted!, params.locale),
   };
-
-  if (context.time === undefined) return metricNotFound(DmMetric.SensorAge, params);
 
   // Build translation key
   const key = 'assistant_responses.sensor_age';

--- a/gluco-check-core/test/fakes/objects/fakeDmQuery.ts
+++ b/gluco-check-core/test/fakes/objects/fakeDmQuery.ts
@@ -10,4 +10,5 @@ export default () =>
     DmMetric.SensorAge,
     DmMetric.CarbsOnBoard,
     DmMetric.PumpBattery,
+    DmMetric.PumpReservoir,
   ]);

--- a/gluco-check-core/test/specs/main/core/Humanizers.spec.ts
+++ b/gluco-check-core/test/specs/main/core/Humanizers.spec.ts
@@ -8,6 +8,7 @@ import I18nHelper from '../../../../src/main/i18n';
 import FormatParams from '../../../../src/types/FormatParams';
 import getFakeQuery from '../../../fakes/objects/fakeDmQuery';
 import {DmMetric} from '../../../../src/types/DmMetric';
+import * as errorHumanizer from '../../../../src/main/i18n/humanizers/_error';
 
 let params: FormatParams;
 
@@ -76,9 +77,15 @@ describe('Humanizer', () => {
   });
 
   it('formats missing metric errors', async () => {
-    const newParams = Object.assign({}, params);
-    newParams.snapshot.carbsOnBoard = undefined;
-    const result = await Humanizers.carbsOnBoard(params);
-    expect(result).toEqual("I couldn't find your carbs on board.");
+    // Use an 'empty' snapshot with no metrics
+    params.snapshot = new DmSnapshot({timestamp: 1, query: params.snapshot.query});
+
+    // Get number of metrics asked for (minus "Everything")
+    const nrOfMetrics = Object.entries(DmMetric).length - 1;
+
+    // MetricNotFound should be called once for each metric
+    jest.spyOn(errorHumanizer, 'metricNotFound');
+    await Humanizers.dmSnapshot(params.snapshot);
+    expect(errorHumanizer.metricNotFound).toHaveBeenCalledTimes(nrOfMetrics);
   });
 });


### PR DESCRIPTION
## Description
This commit moves the check to see if a metric is available before trying to translate it.
That way a timestamp of `NaN` will no longer be incorrectly treated as a valid timestamp.

## Motivation and Context
Asking for the sensor change metric could result in the response being "The sensor was inserted NaN years ago" if the metric wasn't found. It will now be: "Couldn't find your sensor age"

## How Has This Been Tested?
- [x] Unit tests
- [ ] Simulator
- [ ] Live device

## Types of changes
<!--- Delete lines that do not apply -->
* Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Here are some things to consider before merging. You can add/remove items as you see fit. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've made my changes in a separate branch
- [x] I've updated documentation, or created an issue to do so later
- [x] My change is passing new and existing tests