### PR TITLE
Use Codecov action to upload test coverage

### DIFF
--- a/.github/workflows-src/workflow.yml
+++ b/.github/workflows-src/workflow.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: "Upload test coverage results"
         if: ${{ matrix.node-version == '14.x' }}
-        run: bash <(curl -s https://codecov.io/bash)
+        uses: codecov/codecov-action@v1
 
       - name: "Tar workspace"
         if: ${{ matrix.node-version == '14.x' }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -59,7 +59,7 @@ jobs:
         run: yarn workspace gluco-check-frontend run test:ci
       - name: Upload test coverage results
         if: ${{ matrix.node-version == '14.x' }}
-        run: bash <(curl -s https://codecov.io/bash)
+        uses: codecov/codecov-action@v1
       - name: Tar workspace
         if: ${{ matrix.node-version == '14.x' }}
         run: tar -czf ${{ runner.temp }}/workspace.tar ./


### PR DESCRIPTION
## Description
This switches the way coverage results are uploaded from using the bash script to using the official GitHub action.

## Motivation and Context
Codecov security breach in April 2021. This will validate the bash script before running it.