### PR TITLE
fix: Refactor loadDayJsLocale fallback

### DIFF
--- a/gluco-check-core/src/main/i18n/loadDayJsLocale.ts
+++ b/gluco-check-core/src/main/i18n/loadDayJsLocale.ts
@@ -1,29 +1,62 @@
-const availableDayJsLocales = new Set<string>();
+const loadedDayJsLocales = new Set<string>();
 
 /**
- * Extends DayJs with translations so that it can
- * convert timestamps to human form in the specified locale.
- * 300000 ==> '5 minutes'
- * @returns The id of the locale that was loaded. Pass this id to dayjs(foo).locale(id)
+ * Ensures the given locale is available in dayjs.
+ * @param locale The locale to load.
+ * @returns The id of the locale that should be entered in dayjs(foo).locale(id).
  */
-export default async function loadDayJsLocale(_locale: string): Promise<string> {
-  // DayJs uses lowercase to identify its locales
-  const locale = _locale.toLowerCase();
-  const fallback = locale.substr(0, 2);
+export default async function loadDayJsLocale(locale: string): Promise<string> {
+  // Get all possible locale ids
+  const possibleLocaleIds = getPossibleLocaleIds(locale);
 
-  // Bail if locale (or its fallback) was loaded previously
-  if (availableDayJsLocales.has(locale)) return locale;
-  if (availableDayJsLocales.has(fallback)) return fallback;
-
-  try {
-    // Attempt loading the exact locale
-    await import(`dayjs/locale/${locale}`);
-    availableDayJsLocales.add(locale);
-    return locale;
-  } catch (error) {
-    // Attempt loading the fallback
-    await import(`dayjs/locale/${fallback}`);
-    availableDayJsLocales.add(fallback);
-    return fallback;
+  // Check if one of the possible locales is already loaded
+  for (const possibleLocaleId of possibleLocaleIds) {
+    if (loadedDayJsLocales.has(possibleLocaleId)) {
+      return possibleLocaleId;
+    }
   }
+
+  // If no locale is loaded, try to load the first possible one
+  for (const possibleLocaleId of possibleLocaleIds) {
+    try {
+      const loadedLocaleId = await tryLoadingLocale(possibleLocaleId);
+      loadedDayJsLocales.add(loadedLocaleId);
+      return loadedLocaleId;
+    } catch (e) {
+      // If the locale is not available, try the next possible locale
+    }
+  }
+
+  // If no locale could be loaded, throw an error
+  throw new Error(`Could not load locale ${locale}`);
 }
+
+async function tryLoadingLocale(locale: string) {
+  await import(`dayjs/locale/${locale}`);
+  return locale;
+}
+
+/**
+ * Returns all possible locale ids for the given locale.
+ * Example: for 'en-US', returns 'en-us', 'en' and 'custom'
+ */
+function getPossibleLocaleIds(locale: string) {
+  const lowercaseLocale = locale.toLowerCase(); // 'en-US' -> 'en-us'
+  const twoLetterLocale = lowercaseLocale.substring(0, 2); // 'en-US' -> 'en'
+  const customLocale = customFallbackMap.get(twoLetterLocale); // 'en-US' -> 'custom'
+
+  const possibleLocales = [lowercaseLocale, twoLetterLocale];
+
+  // If customLocale exists, add it to the list of possible locale ids
+  if (customLocale) {
+    possibleLocales.push(customLocale);
+  }
+
+  return possibleLocales;
+}
+
+/**
+ * If both the main locale (eg en-US) and its fallback (eg en) fail,
+ * select a fallback from this map.
+ */
+const customFallbackMap = new Map<string, string>([['no', 'nn']]);

--- a/gluco-check-core/test/specs/i18n/loadDayJsLocale.spec.ts
+++ b/gluco-check-core/test/specs/i18n/loadDayJsLocale.spec.ts
@@ -1,0 +1,15 @@
+import loadDayJsLocale from '../../../src/main/i18n/loadDayJsLocale';
+
+describe('loadDayJsLocale', () => {
+  it("falls back to 'en' for 'en-US'", async () => {
+    const expected = 'en';
+    const actual = await loadDayJsLocale('en-US');
+    expect(actual).toBe(expected);
+  });
+
+  it("falls back to 'nn' for 'no-NO'", async () => {
+    const expected = 'nn';
+    const actual = await loadDayJsLocale('no-NO');
+    expect(actual).toBe(expected);
+  });
+});

--- a/gluco-check-core/test/specs/i18n/loadDayJsLocale.spec.ts
+++ b/gluco-check-core/test/specs/i18n/loadDayJsLocale.spec.ts
@@ -12,4 +12,11 @@ describe('loadDayJsLocale', () => {
     const actual = await loadDayJsLocale('no-NO');
     expect(actual).toBe(expected);
   });
+
+  it('throws an error if no locale is found', async () => {
+    const unsupportedLocale = 'unsupported';
+    await expect(loadDayJsLocale(unsupportedLocale)).rejects.toThrow(
+      `Could not load locale ${unsupportedLocale}`
+    );
+  });
 });


### PR DESCRIPTION
## Description
Refactors loadDayJsLocale so it can fall back to a custom locale in case no other is found

## Motivation and Context
The default locale for Norwegian (no-NO) which is used by Google Assistant, has no corresponding locale in DayJS.
This PR refactors the function loadDayJsLocale so that
* it first tries loading the exact locale (eg 'en-us' or 'no-no')
* if that fails, tries loading the two letter locale (eg 'en' or 'no')
* if that fails too, tries loading a custom fallback (eg 'nn')

## How Has This Been Tested?
- [x] New unit test added
- [ ] Using Google Actions Simulator with Norwegian Locale

## Additional context
This PR is required to roll out support for Norwegian (#167)

## Types of changes
* Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Here are some things to consider before merging. You can add/remove items as you see fit. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've made my changes in a separate branch
- [x] My change is passing new and existing tests