### PR TITLE
Italian translation v0.1

### DIFF
--- a/gluco-check-action/definitions/actions/it/actions.yaml
+++ b/gluco-check-action/definitions/actions/it/actions.yaml
@@ -1,0 +1,3 @@
+custom:
+  READ_METRICS: {}
+  actions.intent.MAIN: {}

--- a/gluco-check-action/definitions/custom/intents/it/READ_METRICS.yaml
+++ b/gluco-check-action/definitions/custom/intents/it/READ_METRICS.yaml
@@ -1,0 +1,14 @@
+trainingPhrases:
+- Qual è il mio ($DmMetric 'IOB' auto=false)
+- Quanta ($DmMetric 'insulina' auto=true) rimane
+- Quanti ($DmMetric 'carboidrati attivi' auto=true) ho
+- Quali sono la mia ($DmMetric 'glicemia' auto=true), lo ($DmMetric 'IOB' auto=false) e i ($DmMetric 'carboidrati attivi' auto=false)
+- Qual è la mia ($DmMetric 'glicemia' auto=true)
+- Controlla la mia ($DmMetric 'glicemia' auto=true)
+- ($DmMetric 'Carboidrati attivi' auto=true)
+- Leggi la mia ($DmMetric 'glicemia' auto=true)
+- Richiedi un ($DmMetric 'report completo' auto=true)
+- Quanto tempo ha il mio ($DmMetric 'sensore' auto=true)
+- Chiedi di leggere ($DmMetric 'tutto' auto=true)
+- Ottieni un ($DmMetric 'report completo' auto=true)
+- Chiedi quanto è vecchio il mio ($DmMetric 'pod' auto=true)

--- a/gluco-check-action/definitions/custom/types/it/DmMetric.yaml
+++ b/gluco-check-action/definitions/custom/types/it/DmMetric.yaml
@@ -1,0 +1,47 @@
+synonym:
+  entities:
+    blood sugar:
+      synonyms:
+      - glicemia
+      - zucchero
+    cannula age:
+      synonyms:
+      - età della cannula
+      - cannula
+      - pod
+      - set di infusione
+      - catetere
+    carbs on board:
+      synonyms:
+      - carboidrati attivi
+      - carboidrati
+    everything:
+      synonyms:
+      - tutto
+      - tutti
+      - report completo
+      - tutti i valori
+    insulin on board:
+      synonyms:
+      - insulina attiva
+      - iob
+      - insulina
+      - I.O.B.
+    pump battery:
+      synonyms:
+      - batteria del microinfusore
+      - batteria
+      - livello della batteria
+    pump reservoir:
+      synonyms:
+      - cartuccia del microinfusore
+      - insulina rimanente
+      - unità nel microinfusore
+      - microinfusore
+      - cartuccia
+      - insulina residua
+      - livello del microinfusore
+    sensor age:
+      synonyms:
+      - sensore
+      - età del sensore

--- a/gluco-check-action/definitions/settings/it/settings.yaml
+++ b/gluco-check-action/definitions/settings/it/settings.yaml
@@ -1,0 +1,21 @@
+localizedSettings:
+  developerEmail: niels@glucocheck.app
+  developerName: Niels Maerten
+  displayName: Gluco Check
+  fullDescription: |-
+    Gluco Check porta Nightscout sul tuo Assistente Google. Chiedi il tuo attuale livello di glicemia, quanti carboidrati hai, quando hai cambiato il sensore l'ultima volta e altro ancora.
+
+    Prima di poter utilizzare Gluco Check devi collegare il tuo sito Nightscout su: https://glucocheck.app
+
+    Nota: le informazioni fornite da Gluco Check non sostituiscono le indicazioni del medico.
+  privacyPolicyUrl: https://glucocheck.app/terms/it-IT
+  pronunciation: Gluco Check
+  sampleInvocations:
+  - Parla a Gluco Check
+  - Chiedi a Gluco Check quanto è vecchio il mio sensore
+  - Chiedi a Gluco Check di leggere la mia glicemia
+  - Chiedi a Gluco Check di leggere i miei carboidrati
+  shortDescription: Chiedi a Google di leggere la tua glicemia da Nightscout
+  smallLogoImage: https://lh3.googleusercontent.com/iByZN58udeU-Y00jiCeY5I5piOdBaxzPRutPS1DAO8rhTd2rJJvc55t6aUzkM7b0833W9tAeK4mvlA
+  termsOfServiceUrl: https://glucocheck.app/terms/it-IT
+  voice: female_1

--- a/gluco-check-common/strings/it-IT/assistant-action.md
+++ b/gluco-check-common/strings/it-IT/assistant-action.md
@@ -1,0 +1,88 @@
+# Definizione dell'Azione di Gluco Check
+
+### Note per i traduttori
+
+> Una "frase di invocazione" è qualcosa che dici all'Assistente Google per richiamare Gluco Check.
+> 
+> Non c'è bisogno di fornire traduzioni "esatte" per queste righe. **Usa frasi che suonano naturali nella tua lingua. Qualcosa che diresti effettivamente all'Assistente Google**.
+
+## Frasi di invocazione
+
+- Chiedi quanto è vecchio il mio pod
+- Ottieni un report completo
+- Chiedi di leggere tutto
+- Richiedi un report completo
+- Quanto tempo ha il mio sensore
+- Leggi la mia glicemia
+- Carboidrati attivi
+- Controlla la mia glicemia
+- Qual è la mia glicemia
+- Quali sono la mia glicemia, lo IOB e i carboidrati attivi
+- Quanti carboidrati attivi ho
+- Quanta insulina rimane
+- Qual è il mio IOB
+
+> Se lo desideri, puoi aggiungere più invocazioni.
+
+## Nomi di metriche e Sinonimi
+
+> In ogni invocazione, il nome di una metrica può essere sostituito da qualsiasi altra metrica o da uno dei suoi sinonimi. Prenditi un momento per pensare ai modi in cui questi concetti vengono detti nella tua lingua. Puoi metterne quanti ne vuoi.
+
+- glicemia:
+  - glicemia
+  - zucchero
+  - Glicemia
+- "età" della cannula:
+  - cannula
+  - pod
+  - set di infusione
+  - catetere
+- carboidrati attivi:
+  - carboidrati
+  - carboidrati
+  - carboidrati attivi
+  - Carboidrati Attivi
+- tutto:
+  - tutti
+  - tutti quanti
+  - report completo
+  - tutti i valori
+- insulina attiva:
+  - IOB
+  - insulina
+- batteria del microinfusore:
+  - batteria
+  - livello della batteria
+- cartuccia del microinfusore:
+  - insulina rimanente
+  - unità nel microinfusore
+  - microinfusore
+  - cartuccia
+  - insulina residua
+  - livello del microinfusore
+- "età" del sensore:
+  - sensore
+
+## Assistant Directory Information
+> Le seguenti traduzioni verranno utilizzate nella Google Assistant Directory: https://assistant.google.com/services/a/uid/00000022bd2b313c
+
+> Nel caso in cui il nome "Gluco Check" sia difficile da capire e/o pronunciare nella tua lingua, siamo in grado di cambiarlo con qualcos'altro.
+
+#### Nome dell'app
+Gluco Check
+
+#### Descrizione breve
+Chiedi a Google di leggere la tua glicemia da Nightscout
+
+#### Descrizione completa
+Gluco Check porta Nightscout sul tuo Assistente Google. Chiedi il tuo attuale livello di glicemia, quanti carboidrati hai, quando hai cambiato il sensore l'ultima volta e altro ancora.
+
+Prima di poter utilizzare Gluco Check devi collegare il tuo sito Nightscout su: https://glucocheck.app
+
+Nota: le informazioni fornite da Gluco Check non sostituiscono le indicazioni del medico.
+
+#### Invocazioni evidenziate
+- Parla a Gluco Check
+- Chiedi a Gluco Check quanto è vecchio il mio sensore
+- Chiedi a Gluco Check di leggere la mia glicemia
+- Chiedi a Gluco Check di leggere i miei carboidrati

--- a/gluco-check-common/strings/it-IT/assistant-responses.yaml
+++ b/gluco-check-common/strings/it-IT/assistant-responses.yaml
@@ -1,0 +1,68 @@
+---
+#DO NOT TRANSLATE THIS FILE DIRECTLY
+#If you want to contribute translations, visit https://translate.glucocheck.app
+assistant_responses:
+  blood_sugar:
+    long;with_trend;with_time: >
+      La glicemia è {{value}} e {{trend}} come {{time}} fa.
+    long;no_trend;with_time: >
+      La glicemia è {{value}} come {{time}} fa.
+    long;with_trend;no_time: >
+      La glicemia è {{value}} e {{trend}}.
+    long;no_trend;no_time: >
+      La glicemia è {{value}}.
+    short;no_trend;with_time: >
+      {{value}} come {{time}} fa.
+    short;with_trend;with_time: >
+      {{value}} e {{trend}} come {{time}} fa.
+    trends:
+      DoubleUp: "in crescita veloce"
+      SingleUp: "in crescita"
+      SlightUp: "in crescita leggera"
+      Stable: "stabile"
+      SlightDown: "in discesa leggera"
+      SingleDown: "in discesa"
+      DoubleDown: "in discesa rapida"
+  carbs_on_board:
+    long;with_time: >
+      Ci sono ancora {{value}} carboidrati come {{time}} fa.
+    long;no_time: >
+      Ci sono ancora {{value}} carboidrati.
+    short;with_time: >
+      {{value}} carboidrati come {{time}} fa.
+  insulin_on_board:
+    long;with_time: >
+      Ci sono ancora {{value}} unità di insulina come {{time}} fa.
+    long;no_time: >
+      Ci sono ancora {{value}} unità di insulina.
+    short;with_time: >
+      {{value}} unità di insulina come {{time}} fa.
+  cannula_age: >
+    La cannula è stata inserita {{time}} fa.
+  sensor_age: >
+    Il sensore è stato inserito {{time}} fa.
+  pump_battery: >
+    La batteria del microinfusore è al {{percent}}.
+  pump_reservoir: >
+    Il microinfusore ha {{reservoir}} unità residue.
+  errors:
+    User not found: >
+      Ciao! Grazie per aver scelto di provare Gluco Check. Prima di poter leggere le tue informazioni, dovrai collegarti al tuo sito Nightscout. Per farlo, visito il nostro sito: {{gc_url}}
+    Nightscout Unavailable: >
+      Mi spiace, sembra ci sia un problema con il tuo sito Nightscout. Non sono stato in grado di recuperare le tue informazioni.
+    Nightscout Unauthorized: >
+      Mi spiace, sembra che non possa leggere i dati dal tuo sito Nightscout. Per permettermelo, dovresti prima creare un token. Per farlo, visita il nostro sito: {{gc_url}}
+    DmMetric Not Found: >
+      Non sono riuscito a trovare il tuo {{metric}}.
+common:
+  disclaimer:
+    assistant_IANAD: >
+      Ricorda: non sono un dottore. Se hai bisogno di supporto medico, consulta il tuo diabetologo.
+  metrics:
+    blood sugar: glicemia
+    insulin on board: insulina attiva
+    carbs on board: carboidrati attivi
+    sensor age: '"età" del sensore'
+    cannula age: '"età" della cannula'
+    pump battery: batteria del microinfusore
+    pump reservoir: cartuccia del microinfusore

--- a/gluco-check-common/strings/it-IT/faq.md
+++ b/gluco-check-common/strings/it-IT/faq.md
@@ -3,14 +3,14 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-- [Come posso chiedere a Gluco Check di... ?](#how-do-i-ask-gluco-check-for-)
-  - [una metrica specifica](#a-specific-metric)
-  - [la mia scelta personale](#my-personal-selection)
-  - [metriche multiple](#multiple-metrics)
-- [Altre domande che puoi provare (sperimentale)](#other-questions-you-can-try-experimental)
-- [Posso usare un'invocazione personalizzata?](#can-i-use-a-custom-invocation)
-- [Perchè Nightscout non accetta la mia API secret / token?](#why-is-nightscout-not-accepting-my-api-secret--token)
-- [Ho una domanda diversa!](#i-have-a-different-question)
+- [Come posso chiedere a Gluco Check di... ?](#come-posso-chiedere-a-gluco-check-di-)
+  - [una metrica specifica](#una-metrica-specifica)
+  - [la mia scelta personale](#la-mia-scelta-personale)
+  - [metriche multiple](#metriche-multiple)
+- [Altre domande che puoi provare (sperimentale)](#altre-domande-che-puoi-provare-sperimentale)
+- [Posso usare un'invocazione personalizzata?](#posso-usare-uninvocazione-personalizzata)
+- [Perchè Nightscout non accetta la mia API secret / token?](#perch%C3%A8-nightscout-non-accetta-la-mia-api-secret--token)
+- [Ho una domanda diversa!](#ho-una-domanda-diversa)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/gluco-check-common/strings/it-IT/faq.md
+++ b/gluco-check-common/strings/it-IT/faq.md
@@ -1,0 +1,70 @@
+# Domande Frequenti
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Come posso chiedere a Gluco Check di... ?](#how-do-i-ask-gluco-check-for-)
+  - [una metrica specifica](#a-specific-metric)
+  - [la mia scelta personale](#my-personal-selection)
+  - [metriche multiple](#multiple-metrics)
+- [Altre domande che puoi provare (sperimentale)](#other-questions-you-can-try-experimental)
+- [Posso usare un'invocazione personalizzata?](#can-i-use-a-custom-invocation)
+- [Perchè Nightscout non accetta la mia API secret / token?](#why-is-nightscout-not-accepting-my-api-secret--token)
+- [Ho una domanda diversa!](#i-have-a-different-question)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+---
+
+## Come posso chiedere a Gluco Check di... ?
+
+### una metrica specifica
+
+Dì: **Hey Google, chiedi a Gluco Check di leggere la mia [blank]**.  
+Sostituisci **[blank]** con il nome di una qualsiasi metrica, OPPURE un sinonimo:
+
+| Metrica                     | Sinonimi                                 |
+| --------------------------- | ---------------------------------------- |
+| Glicemia                    | glucosio, zucchero, gli                  |
+| Carboidrati attivi          | carb, COB, carboidrati                   |
+| Insulina attiva             | insulina, IOB                            |
+| "Età" del sensore           | sensore                                  |
+| "Età" del set di infusione  | set di infusione, cannula, catetere, pod |
+| Batteria del microinfusore  | batteria                                 |
+| Cartuccia del microinfusore | insulina rimanente, cartuccia            |
+| _Tutto_                     | _tutti i valori, tutto_                  |
+
+### la mia scelta personale
+
+Dì: **Ehi Google, parla con Gluco Check** senza specificare una metrica.  
+L'assistente leggerà i valori che avrai selezionato su https://glucocheck.app.
+
+### metriche multiple
+
+Say: **Hei Google, chiedi a Gluco Check di leggere la mia _[glicemia]_ e _[età del sensore]_**
+
+## Altre domande che puoi provare (sperimentale)
+
+- Quanto tempo ha il mio sensore? Quanto tempo ha il mio pod?
+- Quanti carboidrati attivi ho?
+- Quanta insulina rimane?
+
+## Posso usare un'invocazione personalizzata?
+
+Sì!  
+Se l'Assistente Google supporta [Routine](https://support.google.com/googlenest/answer/7029585?co=GENIE.Platform%3DAndroid&hl=en) per la tua lingua,  
+segui [queste istruzioni](https://glucocheck.app/routines) per creare le tue invocazioni. Per esempio:
+
+| Invece di...                                     | dì:                                   |
+| ------------------------------------------------ | ------------------------------------- |
+| Ehi Google, chiedi a Gluco Check la mia glicemia | Ehi Google, controlla la mia glicemia |
+
+## Perchè Nightscout non accetta la mia API secret / token?
+
+Le _API secret_ e i _Token_ non sono la stessa cosa.  
+Per utilizzare Gluco Check, avrai bisogno di un _token_. Un token ha questo aspetto: `glucocheck-1d2a6bc59`.  
+Hai bisogno di aiuto? Visita https://glucocheck.app, fai clic su '_Not sure how to create a token? Continua a leggere!_'
+
+## Ho una domanda diversa!
+
+Non hai trovato una risposta qui? Pubblica la tua domanda in [Discussioni](https://github.com/nielsmaerten/gluco-check/discussions). Siamo felici di aiutarti!

--- a/gluco-check-common/strings/it-IT/terms.md
+++ b/gluco-check-common/strings/it-IT/terms.md
@@ -1,0 +1,25 @@
+# Gluco Check
+
+## _Disclaimer Informazioni sanitarie_
+Gluco Check può fornirti solo informazioni generali per aiutarti a monitorare le tue attività. Sebbene ci auguriamo che queste informazioni ti saranno utili, ricorda che non potranno mai sostituire la consulenza di un medico. Parla col tuo medico se hai domande sul trattamento!
+
+## _Informativa sulla privacy_
+Questo documento descrive le informazioni raccolte da  
+Gluco Check, https://github.com/nielsmaerten/gluco-check (il "Servizio" o il "Software") e come utilizziamo queste informazioni.
+
+#### Quali informazioni sono raccolte?
+Quando accedi al Servizio, ti chiediamo l'URL del tuo *sito Nightscout* e un *token*. Lo memorizziamo insieme all'*indirizzo email* del tuo account Google. Ora, quando fai una domanda a Gluco Check, sappiamo quale sito controllare.
+
+
+#### Come vengono utilizzate queste informazioni?
+Quando invochi Gluco Check tramite l'Assistente Google, controlliamo se c'è un Nightscout associato al tuo account Google. In tal caso, raccogliamo le informazioni che hai richiesto al tuo Nightscout e te le leggiamo. Non memorizziamo le informazioni che raccogliamo dal tuo Nightscout. Nemmeno nei log. I nostri registri includono la domanda che hai posto a Gluco Check e quando l'hai fatto. Utilizziamo queste informazioni per capire come viene utilizzato il Servizio e per diagnosticare problemi.
+
+#### Condivisione delle informazioni
+Non condividiamo le tue informazioni con terze parti. Solo i 2 amministratori di Gluco Check (Niels Maerten & David D'Amico) hanno accesso.
+
+#### Cookie
+Utilizziamo Google Analytics per raccogliere informazioni anonime sui visitatori del nostro sito web. Questo vale solo per il nostro sito web, non per l'Azione dell'assistente stesso. Se preferisci, puoi disattivare il cookie di Google Analytics visitando: https://tools.google.com/dlpage/gaoptout/
+
+## _Termini Di Licenza_
+Gluco Check è concesso in licenza con [MIT License](https://github.com/nielsmaerten/gluco-check/blob/main/LICENSE)  
+Copyright (c) 2021 Niels Maerten & David D'Amico

--- a/gluco-check-common/strings/nl-NL/faq.md
+++ b/gluco-check-common/strings/nl-NL/faq.md
@@ -51,6 +51,7 @@ Zeg: **Hey Google, vraag Gluco Check naar mijn _[suiker]_ en _[sensor]_**
 
 ## Kan ik Gluco Check met een andere naam aanspreken?
 
+Ja!  
 Als Google Assistant [Routines](https://support.google.com/googlenest/answer/7029585?co=GENIE.Platform%3DAndroid&hl=en) ondersteunt in jouw taal,  
 kan je met [deze instructies](https://glucocheck.app/routines) je eigen aanroep instellen. Bijvoorbeeld:
 

--- a/gluco-check-common/strings/no-NO/faq.md
+++ b/gluco-check-common/strings/no-NO/faq.md
@@ -3,14 +3,14 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-- [Hvordan spør jeg Gluco Check om... ?](#how-do-i-ask-gluco-check-for-)
-  - [en bestemt beregning](#a-specific-metric)
-  - [mitt personlige valg](#my-personal-selection)
-  - [flere beregninger](#multiple-metrics)
-- [Andre spørsmål du kan prøve (eksperimentelle)](#other-questions-you-can-try-experimental)
-- [Kan jeg bruke en egendefinert frase?](#can-i-use-a-custom-invocation)
-- [Hvorfor godtar ikke Nightscout min API-hemmelighet/token?](#why-is-nightscout-not-accepting-my-api-secret--token)
-- [Jeg har et annet spørsmål!](#i-have-a-different-question)
+- [Hvordan spør jeg Gluco Check om... ?](#hvordan-sp%C3%B8r-jeg-gluco-check-om-)
+  - [en bestemt beregning](#en-bestemt-beregning)
+  - [mitt personlige valg](#mitt-personlige-valg)
+  - [flere beregninger](#flere-beregninger)
+- [Andre spørsmål du kan prøve (eksperimentelle)](#andre-sp%C3%B8rsm%C3%A5l-du-kan-pr%C3%B8ve-eksperimentelle)
+- [Kan jeg bruke en egendefinert frase?](#kan-jeg-bruke-en-egendefinert-frase)
+- [Hvorfor godtar ikke Nightscout min API-hemmelighet/token?](#hvorfor-godtar-ikke-nightscout-min-api-hemmelighettoken)
+- [Jeg har et annet spørsmål!](#jeg-har-et-annet-sp%C3%B8rsm%C3%A5l)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/gluco-check-common/strings/no-NO/faq.md
+++ b/gluco-check-common/strings/no-NO/faq.md
@@ -3,14 +3,14 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-- [Hvordan spør jeg Gluco Check om... ?](#hvordan-sp%C3%B8r-jeg-gluco-check-om-)
-  - [en bestemt beregning](#en-bestemt-beregning)
-  - [mitt personlige valg](#mitt-personlige-valg)
-  - [flere beregninger](#flere-beregninger)
-- [Andre spørsmål du kan prøve (eksperimentelle)](#andre-sp%C3%B8rsm%C3%A5l-du-kan-pr%C3%B8ve-eksperimentelle)
-- [Kan jeg bruke en egendefinert frase?](#kan-jeg-bruke-en-egendefinert-frase)
-- [Hvorfor godtar ikke Nightscout min API-hemmelighet/token?](#hvorfor-godtar-ikke-nightscout-min-api-hemmelighettoken)
-- [Jeg har et annet spørsmål!](#jeg-har-et-annet-sp%C3%B8rsm%C3%A5l)
+- [Hvordan spør jeg Gluco Check om... ?](#how-do-i-ask-gluco-check-for-)
+  - [en bestemt beregning](#a-specific-metric)
+  - [mitt personlige valg](#my-personal-selection)
+  - [flere beregninger](#multiple-metrics)
+- [Andre spørsmål du kan prøve (eksperimentelle)](#other-questions-you-can-try-experimental)
+- [Kan jeg bruke en egendefinert frase?](#can-i-use-a-custom-invocation)
+- [Hvorfor godtar ikke Nightscout min API-hemmelighet/token?](#why-is-nightscout-not-accepting-my-api-secret--token)
+- [Jeg har et annet spørsmål!](#i-have-a-different-question)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/gluco-check-frontend/firebase.json
+++ b/gluco-check-frontend/firebase.json
@@ -76,6 +76,11 @@
         "source": "/join-beta/no",
         "destination": "https://github.com/nielsmaerten/gluco-check/discussions/165",
         "type": 307
+      },
+      {
+        "source": "/join-beta/it",
+        "destination": "https://github.com/nielsmaerten/gluco-check/discussions/173",
+        "type": 307
       }
     ]
   }

--- a/gluco-check-frontend/public/locales/de/translation.json
+++ b/gluco-check-frontend/public/locales/de/translation.json
@@ -139,6 +139,7 @@
       "de": "Deutsch",
       "en": "English",
       "es": "Español",
+      "it": "Italiano",
       "nl": "Nederlands",
       "no": "Norsk",
       "sv": "Svenska"

--- a/gluco-check-frontend/public/locales/en/translation.json
+++ b/gluco-check-frontend/public/locales/en/translation.json
@@ -139,6 +139,7 @@
       "de": "Deutsch",
       "en": "English",
       "es": "Español",
+      "it": "Italiano",
       "nl": "Nederlands",
       "no": "Norsk",
       "sv": "Svenska"

--- a/gluco-check-frontend/public/locales/es/translation.json
+++ b/gluco-check-frontend/public/locales/es/translation.json
@@ -139,6 +139,7 @@
       "de": "Deutsch",
       "en": "English",
       "es": "Español",
+      "it": "Italiano",
       "nl": "Nederlands",
       "no": "Norsk",
       "sv": "Svenska"

--- a/gluco-check-frontend/public/locales/it/translation.json
+++ b/gluco-check-frontend/public/locales/it/translation.json
@@ -40,7 +40,7 @@
     "title": "Modifica impostazioni",
     "betaBanner": {
       "action": "Voglio aiutarti",
-      "title": "Attenzione! Gluco Check non è ancora disponibile in [[your language]]",
+      "title": "Attenzione! Gluco Check non è ancora disponibile in Italiano",
       "message": "Parli sia {{language}} che inglese? Puoi aiutarci a completare questa traduzione."
     },
     "form": {
@@ -131,17 +131,18 @@
       "image_alt": ""
     }
   },
-  "i18nCode": "en-US",
+  "i18nCode": "it-IT",
   "languageSelector": {
     "buttonLabel": "Lingua",
     "contribute": "Contribuisci alle traduzioni",
     "availableLanguageLabels": {
-      "de": "Tedesco",
-      "en": "Inglese",
-      "es": "Spagnolo",
-      "nl": "Olandese",
-      "no": "Norvegese",
-      "sv": "Svedese"
+      "de": "Deutsch",
+      "en": "English",
+      "es": "Español",
+      "it": "Italiano",
+      "nl": "Nederlands",
+      "no": "Norsk",
+      "sv": "Svenska"
     }
   }
 }

--- a/gluco-check-frontend/public/locales/it/translation.json
+++ b/gluco-check-frontend/public/locales/it/translation.json
@@ -1,0 +1,147 @@
+{
+  "title": "Gluco Check",
+  "status": {
+    "general": {
+      "loading": "Caricamento",
+      "error": "Qualcosa è andato storto"
+    }
+  },
+  "landing": {
+    "title": "Benvenuto su Gluco Check",
+    "subtitle": "Gluco Check porta Nightscout sul tuo Google Home"
+  },
+  "onboarding": {
+    "q1": "Ehi Google, chiedi a Gluco Check la mia glicemia.",
+    "a1": "6.5 e stabile fino a cinque minuti fa.",
+    "l1": "Glicemia",
+    "q2": "Ehi Google, chiedi a Gluco Check il mio COB",
+    "a2": "Ci sono 10 carboidrati attivi.",
+    "l2": "Carboidrati Attivi",
+    "q3": "Ehi Google, chiedi a Gluco Check tutto",
+    "a3": "La glicemia è 6.1. Ci sono 12 carboidrati attivi. L'età del sensore è...",
+    "l3": "Tutto"
+  },
+  "boilerplate": {
+    "terms": "Continuando, stai indicando che accetto i nostri<0>Termini di servizio</0> e <1>Privacy Policy</1>.",
+    "google": "Google Assistant è un marchio registrato di Google Inc.",
+    "nightscout": "Non affiliato al <2>Progetto Nightscout</2>",
+    "logout": "Disconnetti"
+  },
+  "welcome": {
+    "title": "Benvenuto su Gluco Check",
+    "subtitle": "Gluco Check porta Nightscout sul tuo Google Home",
+    "cta": "Collega il tuo Nightscout"
+  },
+  "login": {
+    "title": "Accedi",
+    "buttonLabel": "Accedi con Google"
+  },
+  "settings": {
+    "title": "Modifica impostazioni",
+    "betaBanner": {
+      "action": "Voglio aiutarti",
+      "title": "Attenzione! Gluco Check non è ancora disponibile in [[your language]]",
+      "message": "Parli sia {{language}} che inglese? Puoi aiutarci a completare questa traduzione."
+    },
+    "form": {
+      "validationInProgress": "Verifica del tuo sito Nightscout",
+      "labels": {
+        "glucoseUnits": "Unità glicemica",
+        "nightscoutToken": "Token Nightscout",
+        "nightscoutUrl": "URL di Nightscout",
+        "defaultMetrics": "L'assistente ti leggerà questi elementi per impostazione predefinita"
+      },
+      "helperText": {
+        "nightscoutToken": {
+          "default": "Non sai come ottenere un token? Continuare a leggere!",
+          "empty": "Potresti non avere accesso a tutte le metriche senza un token valido",
+          "invalid": "Questo token non ha funzionato"
+        },
+        "nightscoutUrl": {
+          "default": "URL del tuo Nightscout",
+          "required": "Questo campo è obbligatorio",
+          "notNightscout": "Questo URL non punta a un sito Nightscout",
+          "needsUpgrade": "Il tuo sito Nightscout richiede un aggiornamento per funzionare con Gluco Check, per favore aggiorna ad almeno {{version}}"
+        },
+        "defaultMetrics": {
+          "required": "Devi selezionare almeno una traccia",
+          "notAvailableInvalidToken": "* Avrai bisogno di un token valido per accedere a queste tracce",
+          "notAvailableValidToken": "* Non abbiamo trovato un valore recente per queste tracce, ma puoi comunque selezionarle"
+        },
+        "glucoseUnits": {
+          "mismatch": "L'unità scelta è diversa dalle unità del tuo sito Nightscout"
+        }
+      },
+      "submitButton": "Salva impostazioni",
+      "submitStatus": {
+        "submitting": "Salvando le tue impostazioni",
+        "submitted": "Impostazioni salvate",
+        "error": "Qualcosa è andato terribilmente storto salvando le impostazioni"
+      }
+    }
+  },
+  "navigation": {
+    "faqs": "Aiuto & Domande frequenti",
+    "github": "Cercaci su Github"
+  },
+  "diabetesMetrics": {
+    "Everything": "tutto",
+    "BloodSugar": "glicemia",
+    "InsulinOnBoard": "insulina attiva",
+    "CarbsOnBoard": "carboidrati attivi",
+    "SensorAge": "\"età\" del sensore",
+    "CannulaAge": "\"età\" della cannula",
+    "PumpBattery": "batteria del microinfusore",
+    "PumpReservoir": "cartuccia del microinfusore"
+  },
+  "tokenDialog": {
+    "title": "Generare un token Nightscout",
+    "preamble": "Per funzionalità di base come il controllo dei tuoi numeri, il tuo Url di Nightscout è sufficiente. Per funzionalità più avanzate, avrai bisogno di un token con autorizzazioni di lettura Api complete. Se non sai cosa significa, non preoccuparti! Lo esamineremo un passo alla volta.",
+    "links": {
+      "howToUpdateNightscout": "http://www.nightscout.info/wiki/faqs-2/azure/updating-your-website-to-the-latest-release-pull-request",
+      "glucoCheckSettings": "impostazioni"
+    },
+    "step1": {
+      "label": "Controlla la versione di Nightscout",
+      "description": "Innanzitutto, assicurati che il tuo sito sia almeno alla versione 14 di Nightscout. Puoi controllare la versione facendo clic sul pulsante del menu \"hamburger\" e guardando qui:",
+      "image": "nightscout-version.png",
+      "image_alt": ""
+    },
+    "step2": {
+      "label": "Aggiorna Nightscout",
+      "description": "Se hai bisogno di un aggiornamento, puoi leggere di più su come farlo <2>qui</2>. In caso contrario, facciamo quel token!"
+    },
+    "step3": {
+      "label": "Crea Ruolo e Oggetto",
+      "description": "Fai clic sul menu \"hamburger\", quindi su \"Strumenti di amministrazione\"."
+    },
+    "step4": {
+      "description": "Fai clic su \"Aggiungi nuovo ruolo\", compila il ruolo con i valori illustrati di seguito e fai clic su Salva.",
+      "image": "edit-role.png",
+      "image_alt": ""
+    },
+    "step5": {
+      "description": "Fai clic su \"Aggiungi nuovo Oggetto\", compila l'Oggetto con i valori illustrati di seguito e fai clic su Salva.",
+      "image": "edit-subject.png",
+      "image_alt": ""
+    },
+    "step6": {
+      "description": "Copia il valore nella colonna \"Access Token\", incollalo nel campo Nightscout Token in <2>Gluco Check Settings</2> e fai clic su salva.",
+      "image": "copy-token.png",
+      "image_alt": ""
+    }
+  },
+  "i18nCode": "en-US",
+  "languageSelector": {
+    "buttonLabel": "Lingua",
+    "contribute": "Contribuisci alle traduzioni",
+    "availableLanguageLabels": {
+      "de": "Tedesco",
+      "en": "Inglese",
+      "es": "Spagnolo",
+      "nl": "Olandese",
+      "no": "Norvegese",
+      "sv": "Svedese"
+    }
+  }
+}

--- a/gluco-check-frontend/public/locales/nl/translation.json
+++ b/gluco-check-frontend/public/locales/nl/translation.json
@@ -139,6 +139,7 @@
       "de": "Deutsch",
       "en": "English",
       "es": "Español",
+      "it": "Italiano",
       "nl": "Nederlands",
       "no": "Norsk",
       "sv": "Svenska"

--- a/gluco-check-frontend/public/locales/nl/translation.json
+++ b/gluco-check-frontend/public/locales/nl/translation.json
@@ -39,9 +39,9 @@
   "settings": {
     "title": "Instellingen",
     "betaBanner": {
-      "action": "Ik wil helpen",
-      "title": "Let op! Gluco Check is nog niet beschikbaar in het Nederlands",
-      "message": "Spreek je zowel Nederlands als Engels? Dan kan je ons helpen deze vertaling af te werken."
+      "action": "Ik kan helpen",
+      "title": "Let op! Gluco Check is nog niet beschikbaar in Nederlands",
+      "message": "Spreek je zowel {{language}} als Engels? Dan kan je ons helpen deze vertaling te vervolledigen."
     },
     "form": {
       "validationInProgress": "Nightscout site wordt gecontroleerd",

--- a/gluco-check-frontend/public/locales/no/translation.json
+++ b/gluco-check-frontend/public/locales/no/translation.json
@@ -40,7 +40,7 @@
     "title": "Endre innstillinger",
     "betaBanner": {
       "action": "Jeg vil hjelpe",
-      "title": "Vær oppmerksom! Gluco Check er ennå ikke tilgjengelig på norsk",
+      "title": "Vær oppmerksom! Gluco Check er ennå ikke tilgjengelig på [[your language]]",
       "message": "Snakker du både {{language}} og engelsk? Du kan hjelpe oss med å fullføre denne oversettelsen."
     },
     "form": {
@@ -131,17 +131,17 @@
       "image_alt": ""
     }
   },
-  "i18nCode": "no-NO",
+  "i18nCode": "en-US",
   "languageSelector": {
     "buttonLabel": "Språk",
     "contribute": "Bidra med oversettelser",
     "availableLanguageLabels": {
-      "de": "Deutsch",
-      "en": "English",
-      "es": "Español",
-      "nl": "Nederlands",
+      "de": "Tysk",
+      "en": "Engelsk",
+      "es": "Spansk",
+      "nl": "Nederlandsk",
       "no": "Norsk",
-      "sv": "Svenska"
+      "sv": "Svensk"
     }
   }
 }

--- a/gluco-check-frontend/public/locales/no/translation.json
+++ b/gluco-check-frontend/public/locales/no/translation.json
@@ -136,12 +136,13 @@
     "buttonLabel": "Språk",
     "contribute": "Bidra med oversettelser",
     "availableLanguageLabels": {
-      "de": "Tysk",
-      "en": "Engelsk",
-      "es": "Spansk",
-      "nl": "Nederlandsk",
+      "de": "Deutsch",
+      "en": "English",
+      "es": "Español",
+      "it": "Italiano",
+      "nl": "Nederlands",
       "no": "Norsk",
-      "sv": "Svensk"
+      "sv": "Svenska"
     }
   }
 }

--- a/gluco-check-frontend/public/locales/sv/translation.json
+++ b/gluco-check-frontend/public/locales/sv/translation.json
@@ -136,11 +136,13 @@
     "buttonLabel": "Språk",
     "contribute": "Bidra med översättningar",
     "availableLanguageLabels": {
+      "de": "Deutsch",
       "en": "English",
-      "nl": "Nederlands",
       "es": "Español",
-      "sv": "Svenska",
-      "de": "Deutsch"
+      "it": "Italiano",
+      "nl": "Nederlands",
+      "no": "Norsk",
+      "sv": "Svenska"
     }
   }
 }

--- a/gluco-check-frontend/src/lib/enums.ts
+++ b/gluco-check-frontend/src/lib/enums.ts
@@ -27,6 +27,7 @@ export enum AvailableLanguage {
   Dutch = "nl",
   English = "en",
   German = "de",
+  Italian = "it",
   Norwegian = "no",
   Spanish = "es",
   Swedish = "sv",
@@ -36,6 +37,7 @@ export enum AvailableLanguage {
 // We'll show a message informing users they have to sign up to get access.
 export enum BetaLanguage {
   German = AvailableLanguage.German,
+  Italian = AvailableLanguage.Italian,
   Norwegian = AvailableLanguage.Norwegian,
   Spanish = AvailableLanguage.Spanish,
   Swedish = AvailableLanguage.Swedish,


### PR DESCRIPTION
## Description
Thanks to **AccoBo** and **tonyco98** for contributing the Italian translations! 🎉

**Email beta@glucocheck.app or leave a comment below if you'd like to test Gluco Check in Italian**

## To do
- [ ] Enable translation in backend (happens automatically when released to prod)
- [x] Enable translation on frontend
  - [x] beta notification appears
    - [x] 'i want to help' button works
    - [x] beta notification contains the language name
  - [x] language appears in dropdown
  - [x] pages.glucocheck.app shows 'looking for testers'
  - [x] FAQ index regenerated
  - [x] Set i18nCode
- [x] Deploy updated action definition to Preview Channel
  - [x] insert directory information
  - [x] insert new invocation phrases
  - [x] insert new types

## After releasing update to _prod._
- [ ] Simulator queries are working
- [ ] Updates are tested on a real device
- [ ] Sample invocation phrases are working IRL
