### PR TITLE
fix: format Norwegian timeAgo to bokmål 

### DIFF
--- a/gluco-check-core/src/main/i18n/loadDayJsLocale.ts
+++ b/gluco-check-core/src/main/i18n/loadDayJsLocale.ts
@@ -43,7 +43,7 @@ async function tryLoadingLocale(locale: string) {
 function getPossibleLocaleIds(locale: string) {
   const lowercaseLocale = locale.toLowerCase(); // 'en-US' -> 'en-us'
   const twoLetterLocale = lowercaseLocale.substring(0, 2); // 'en-US' -> 'en'
-  const customLocale = customFallbackMap.get(twoLetterLocale); // 'en-US' -> 'custom'
+  const customLocale = customFallbackMap.get(twoLetterLocale); // 'no-NO' -> 'nb'
 
   const possibleLocales = [lowercaseLocale, twoLetterLocale];
 
@@ -59,4 +59,4 @@ function getPossibleLocaleIds(locale: string) {
  * If both the main locale (eg en-US) and its fallback (eg en) fail,
  * select a fallback from this map.
  */
-const customFallbackMap = new Map<string, string>([['no', 'nn']]);
+const customFallbackMap = new Map<string, string>([['no', 'nb']]);

--- a/gluco-check-core/test/specs/i18n/loadDayJsLocale.spec.ts
+++ b/gluco-check-core/test/specs/i18n/loadDayJsLocale.spec.ts
@@ -7,8 +7,8 @@ describe('loadDayJsLocale', () => {
     expect(actual).toBe(expected);
   });
 
-  it("falls back to 'nn' for 'no-NO'", async () => {
-    const expected = 'nn';
+  it("falls back to 'nb' for 'no-NO'", async () => {
+    const expected = 'nb';
     const actual = await loadDayJsLocale('no-NO');
     expect(actual).toBe(expected);
   });


### PR DESCRIPTION
## Description
As reported by @SanderRemote20, the Norwegian locale is using bokmål , but was formatting timestamps using nynorsk.
This commit aligns both to use bokmål 

## Context

> It looks like it's Nynorsk based on the response.
"Noen" (some/few) becomes nokre, "minutter" (minutes) becomes "minutt", "måneder" (months) becomes "månadar" (actually written månader in nynorsk).
In nynorsk, "enheter" (units) is written "einingar".
So it looks like a mix of bokmål and nynorsk.

## How Has This Been Tested?
See #167 


## Types of changes
<!--- Delete lines that do not apply -->
* Bug fix (non-breaking change which fixes an issue)