### PR TITLE
fix: Don't write nightscout urls to logs

### DIFF
--- a/gluco-check-core/src/main/clients/nightscout/NightscoutClient.ts
+++ b/gluco-check-core/src/main/clients/nightscout/NightscoutClient.ts
@@ -16,7 +16,7 @@ const logTag = '[NightscoutClient]';
  */
 export default class NightscoutClient {
   constructor(private nightscoutProps: NightscoutProps) {
-    logger.debug(logTag, 'Initializing for:', nightscoutProps.url);
+    //logger.debug(logTag, 'Initializing for:', nightscoutProps.url);
     axios.interceptors.response.use(this.unwrap);
   }
   private cache: Record<string, Promise<any>> = {};


### PR DESCRIPTION
## Description
NightscoutClient used to log the full url of a site when it was initialized.
This PR disables that logging statement.

## Motivation and Context
Logs are automatically purged after 7 days, but there's little use in logging this info anyways. So I'm just removing it.

## How Has This Been Tested?
Untested.

## Checklist:
<!--- Here are some things to consider before merging. You can add/remove items as you see fit. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've made my changes in a separate branch
- [x] My change is passing new and existing tests